### PR TITLE
Fix esp-hal #2740 ADC leak; centralise deep-sleep entry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,18 @@ e1001 = [] # Seeed reTerminal E1001 (7", GDEY075T7 panel, 800x480 4-level graysc
 e1002 = [] # Seeed reTerminal E1002 (7", GDEP073E01 panel, 800x480)
 e1004 = [] # Seeed reTerminal E1004 (13", T133A01 panel, 1200x1600)
 
+# PPK2 bench-measurement mode (E1004 only). On boot, parks the SY6974B
+# charger in HIZ so the system rail runs entirely from the BAT input,
+# regardless of USB-C state. Intended for a Nordic Power Profiler Kit II
+# in source mode wired to the BAT pins (replacing the cell): PPK2
+# supplies a constant voltage and measures the real system current while
+# USB-C stays connected for `esptool` flash and the CH340K serial console
+# (CH340K is powered from VBUS via a separate LDO, independent of the
+# charger). Also disables the chip's I²C watchdog so HIZ doesn't
+# auto-clear after 40 s. The cell, if also connected, will not charge
+# while this build runs.
+ppk2 = []
+
 [dependencies]
 esp-hal = { version = "1.1.0", features = ["esp32s3", "unstable"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ e1004 = [] # Seeed reTerminal E1004 (13", T133A01 panel, 1200x1600)
 # charger). Also disables the chip's I²C watchdog so HIZ doesn't
 # auto-clear after 40 s. The cell, if also connected, will not charge
 # while this build runs.
-ppk2 = []
+disable_charger = []
 
 [dependencies]
 esp-hal = { version = "1.1.0", features = ["esp32s3", "unstable"] }

--- a/POWER.md
+++ b/POWER.md
@@ -1,0 +1,86 @@
+Power profile — E1004
+=====================
+
+Bench measurements taken with a Nordic Power Profiler Kit II in
+source-meter mode wired to the E1004 BAT pads (replacing the cell)
+at 3700 mV.
+
+Headline: deep-sleep floor went from **1.585 mA → ~250 µA** (≈6×) by
+clearing one register before `rtc.sleep_deep(...)`.
+
+Root cause
+----------
+
+[esp-rs/esp-hal#2740](https://github.com/esp-rs/esp-hal/issues/2740):
+`Adc::new` sets `SENS.sar_power_xpd_sar.force_xpd_sar` and nothing in
+the API ever clears it, so the SAR analog stays powered through deep
+sleep. ~1.3 mA constant draw on ESP32-S3 once any code calls
+`Adc::new` — we hit this every cycle through `read_battery`.
+
+esp-hal #5279 (every `WakeSource::apply()` calls
+`set_rtc_peri_pd_en(false)`) was initially suspected of being a
+co-contributor; bench bisection showed it isn't material on this
+hardware. Clearing the SAR XPD bit alone is sufficient to reach the
+~250 µA floor.
+
+Fix in `src/sleep.rs`, immediately before sleep:
+
+```rust
+SENS::regs()
+    .sar_power_xpd_sar()
+    .modify(|_, w| unsafe { w.force_xpd_sar().bits(0) });
+```
+
+Power budget
+------------
+
+Cell: **5000 mAh × 3.7 V = 18,500 mWh** nominal.
+
+Per active refresh cycle (cold-boot or button-wake, equivalent):
+**~36 J ≈ 10 mWh**, ~42 s wall-clock end to end.
+
+| Refresh interval  | Active (mWh/day) | Sleep (mWh/day) | Total (mWh/day) | Battery life     |
+|-------------------|------------------|-----------------|-----------------|------------------|
+| **24 h (1/day)**  | 10               | 22              | **32**          | **~575 days (~19 months)** |
+| 12 h (2/day)      | 20               | 22              | 42              | ~440 days (~14 months)     |
+|  6 h (4/day)      | 40               | 22              | 62              | ~300 days (~10 months)     |
+|  1 h (24/day)     | 240              | 22              | 262             | ~70 days (~2.3 months)     |
+
+Sleep math: 250 µA × 3.7 V × 24 h ≈ 22 mWh/day.
+
+At a daily refresh, sleep is ~70% of daily energy, active ~30%.
+Without the fix, sleep would have been ~140 mWh/day and the same
+1-refresh-per-day cell life would be ~120 days (~4 months) — the fix
+extends life ~4.7× at this duty cycle.
+
+Active cycle waveform
+---------------------
+
+| Phase              | Time         | Mean current | Notes                                     |
+|--------------------|--------------|--------------|-------------------------------------------|
+| Boot ramp          | 0 – 2 s      | ~70 → 180 mA | ESP32-S3 + radio bring-up; 1.08 A peak    |
+| WiFi assoc + fetch | 2 – 12 s     | ~250 mA      | sustained, with sub-second 0.5 A bursts   |
+| Panel transition   | 12 – 41 s    | ~180–330 mA  | matches the panel's ~20 s e-ink refresh   |
+| Deep sleep         | 42 s onward  | ~250 µA      |                                           |
+
+Bench setup notes
+-----------------
+
+PPK2 in source-meter mode replaces the cell at the BAT pads. Build
+with the `disable_charger` Cargo feature, which parks the SY6974B in
+HIZ so the PPK2 sees the real load even with USB-C attached, and
+disables the chip's I²C watchdog so HIZ is sticky across resets:
+
+```
+EXTRA_FEATURES=disable_charger RELEASE=1 ./run.sh e1004 /dev/ttyUSB0 /tmp/flash.log
+```
+
+Drive the PPK2 from Nordic's nRF Connect for Desktop (Power
+Profiler app) for live current display and capture.
+
+**Bench gotcha:** with `disable_charger` active, EN_HIZ is sticky
+across ESP32 resets and only clears when VBUS is removed and
+reapplied. Once firmware has run, the device only boots if the PPK2
+is sourcing on BAT — if the supply script exits between flashes, the
+next reset brownouts. Keep one PPK2-supply script running for the
+whole bench session.

--- a/run.sh
+++ b/run.sh
@@ -60,5 +60,11 @@ release_flag=""
 if [[ "${RELEASE:-}" == "1" ]]; then
     release_flag="--release"
 fi
+# `EXTRA_FEATURES=foo,bar` env var appends extra cargo features
+# alongside the device feature — e.g. `disable_charger` for PPK2 bench builds.
+features="$device"
+if [[ -n "${EXTRA_FEATURES:-}" ]]; then
+    features="${features},${EXTRA_FEATURES}"
+fi
 echo $$ > "$pid_file"
-exec script -qfc "cargo run $release_flag --features $device -- --port $port" "$log"
+exec script -qfc "cargo run $release_flag --features $features -- --port $port" "$log"

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -274,7 +274,7 @@ async fn main(spawner: Spawner) -> ! {
     // possible drawing through VBUS. This must happen after I²C0 is up
     // (the chip lives on this bus) but before any code that depends on
     // the BAT-only power path being established.
-    #[cfg(all(feature = "e1004", feature = "ppk2"))]
+    #[cfg(all(feature = "e1004", feature = "disable_charger"))]
     let i2c0 = epd_photoframe::sy6974b::enter_measurement_mode(i2c0).await;
 
     spawner.spawn(

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -116,7 +116,6 @@ fn determine_wake_action(
     }
 }
 
-
 #[embassy_executor::task]
 async fn blink_task(mut led: Output<'static>) {
     loop {

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -268,6 +268,15 @@ async fn main(spawner: Spawner) -> ! {
             .with_sda(peripherals.GPIO19)
             .with_scl(peripherals.GPIO20)
             .into_async();
+
+    // PPK2 measurement mode: park the SY6974B charger in HIZ before
+    // anything else runs so the system rail spends as little time as
+    // possible drawing through VBUS. This must happen after I²C0 is up
+    // (the chip lives on this bus) but before any code that depends on
+    // the BAT-only power path being established.
+    #[cfg(all(feature = "e1004", feature = "ppk2"))]
+    let i2c0 = epd_photoframe::sy6974b::enter_measurement_mode(i2c0).await;
+
     spawner.spawn(
         epd_photoframe::normal_mode::sensor_task(
             Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ pub mod qr_image;
 pub mod rtc_persisted;
 pub mod sht40;
 pub mod single_shot_wifi;
+pub mod sleep;
 pub mod sy6974b;
 pub mod uart;
 pub mod url_util;

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -172,7 +172,7 @@ impl From<String> for FetchError {
 /// the fallback timer) or a button press.
 pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
     let HardwareCtx {
-        mut rtc,
+        rtc,
         wake_action,
         wifi,
         mut gpio_btn_refresh,
@@ -482,25 +482,7 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
             esp_hal::rtc_cntl::sleep::WakeupLevel::Low,
         ),
     ];
-    let pin_wake_source = esp_hal::rtc_cntl::sleep::RtcioWakeupSource::new(wakeup_pins);
-
-    // Convert the absolute wake-up `Instant` back into a relative
-    // duration as late as possible, so any time still spent below
-    // (UART flush etc.) doesn't inflate it. `sleep_deep` takes a
-    // `core::time::Duration`, so we bridge through micros. Expect a
-    // residual drift on the order of a second over hours-scale sleeps:
-    // the RTC-slow clock is the internal 150 kHz RC oscillator, and
-    // even with esp-hal's calibration its accuracy is bounded.
-    let remaining = wakeup_requested.saturating_duration_since(embassy_time::Instant::now());
-    let sleep_duration = core::time::Duration::from_micros(remaining.as_micros());
-    println!("Deep sleep for {:?}", sleep_duration);
-    let timer_wake_source = esp_hal::rtc_cntl::sleep::TimerWakeupSource::new(sleep_duration);
-    let wake_sources: &[&dyn esp_hal::rtc_cntl::sleep::WakeSource] =
-        &[&timer_wake_source, &pin_wake_source];
-
-    println!("Going to deep sleep :)");
-    wait_for_tx_idle();
-    rtc.sleep_deep(wake_sources);
+    crate::sleep::start_sleep(rtc, Some(wakeup_requested), wakeup_pins);
 }
 
 /// Parse a `Refresh: <secs>[; url=<url>]` header value into a

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -244,11 +244,8 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
     // serialise the two and waste that overlap.
     let fetch_result: Result<(Vec<u8>, Option<RefreshHint>), FetchError> = {
         let base_url_ref = current_url.as_str();
-        let wifi_result = single_shot_wifi::run(
-            wifi,
-            &creds,
-            WIFI_LINK_TIMEOUT,
-            |stack| async move {
+        let wifi_result =
+            single_shot_wifi::run(wifi, &creds, WIFI_LINK_TIMEOUT, |stack| async move {
                 let battery_mv = BATTERY_MV.wait().await;
                 let battery_pct = battery::mv_to_percentage(battery_mv);
                 let temp_humidity = TEMP_HUMIDITY.wait().await;
@@ -284,9 +281,8 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
                 };
                 println!("Fetching {}", fetch_url);
                 try_fetch(stack, &fetch_url).await
-            },
-        )
-        .await;
+            })
+            .await;
         match wifi_result {
             Ok(inner) => inner,
             Err(e) => Err(FetchError::from(e.message(&creds.ssid))),
@@ -327,17 +323,21 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
                     // `/screen/foo`), so resolve against whatever we just
                     // fetched rather than the NVS base.
                     Some(raw) => match url_util::resolve(&current_url, raw) {
-                        Some(abs) => match heapless::String::<STORED_URL_MAX>::try_from(abs.as_str())
-                        {
-                            Ok(stored) => {
-                                println!("Stashing redirect URL for next Timer wake: {}", abs);
-                                REDIRECT_URL.set(stored);
+                        Some(abs) => {
+                            match heapless::String::<STORED_URL_MAX>::try_from(abs.as_str()) {
+                                Ok(stored) => {
+                                    println!("Stashing redirect URL for next Timer wake: {}", abs);
+                                    REDIRECT_URL.set(stored);
+                                }
+                                Err(heapless::CapacityError { .. }) => {
+                                    println!(
+                                        "Redirect URL too long ({} bytes); dropping",
+                                        abs.len()
+                                    );
+                                    REDIRECT_URL.clear();
+                                }
                             }
-                            Err(heapless::CapacityError { .. }) => {
-                                println!("Redirect URL too long ({} bytes); dropping", abs.len());
-                                REDIRECT_URL.clear();
-                            }
-                        },
+                        }
                         None => {
                             println!("Unresolvable redirect URL {:?}; dropping", raw);
                             REDIRECT_URL.clear();
@@ -465,7 +465,6 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
     let _ = epd;
 
     println!("Deep sleep!");
-
     let wakeup_pins: &mut [(
         &mut dyn esp_hal::gpio::RtcPin,
         esp_hal::rtc_cntl::sleep::WakeupLevel,

--- a/src/panel/grayscale.rs
+++ b/src/panel/grayscale.rs
@@ -38,8 +38,8 @@ mod tests {
 
     #[test]
     fn anchor_grays_round_to_their_own_level() {
-        assert_eq!(level(  0,   0,   0), 0);
-        assert_eq!(level( 85,  85,  85), 1);
+        assert_eq!(level(0, 0, 0), 0);
+        assert_eq!(level(85, 85, 85), 1);
         assert_eq!(level(170, 170, 170), 2);
         assert_eq!(level(255, 255, 255), 3);
     }
@@ -49,8 +49,8 @@ mod tests {
         // Boundaries fall at the midpoints 42.5 / 127.5 / 212.5; integer
         // round-half-up via `+42` puts the integer just below each midpoint
         // in the lower bucket and the one just above into the upper.
-        assert_eq!(level( 42,  42,  42), 0);
-        assert_eq!(level( 43,  43,  43), 1);
+        assert_eq!(level(42, 42, 42), 0);
+        assert_eq!(level(43, 43, 43), 1);
         assert_eq!(level(127, 127, 127), 1);
         assert_eq!(level(128, 128, 128), 2);
         assert_eq!(level(212, 212, 212), 2);
@@ -60,10 +60,10 @@ mod tests {
     #[test]
     fn bt601_weighting() {
         // Pure red: luma = 0.299·255 ≈ 76 → bucket 1 (closer to 85 than 0).
-        assert_eq!(level(255,   0,   0), 1);
+        assert_eq!(level(255, 0, 0), 1);
         // Pure green: luma = 0.587·255 ≈ 150 → bucket 2 (closer to 170).
-        assert_eq!(level(  0, 255,   0), 2);
+        assert_eq!(level(0, 255, 0), 2);
         // Pure blue: luma = 0.114·255 ≈ 29 → bucket 0 (closer to 0).
-        assert_eq!(level(  0,   0, 255), 0);
+        assert_eq!(level(0, 0, 255), 0);
     }
 }

--- a/src/panel/spectra6.rs
+++ b/src/panel/spectra6.rs
@@ -110,12 +110,54 @@ impl ChromaColor {
 /// integer; the resulting closest-anchor classifier agrees with all
 /// 96 (palette × colour) reference rows.
 const SPECTRA_6_CHROMA_ANCHORS: &[(ChromaColor, Spectra6Color)] = &[
-    (ChromaColor { x:  -30, y:  -36, v:  93 }, Spectra6Color::Black),
-    (ChromaColor { x:  -42, y:  -13, v: 451 }, Spectra6Color::White),
-    (ChromaColor { x:  239, y:  402, v: 450 }, Spectra6Color::Yellow),
-    (ChromaColor { x:  310, y:   16, v: 328 }, Spectra6Color::Red),
-    (ChromaColor { x: -268, y: -195, v: 369 }, Spectra6Color::Blue),
-    (ChromaColor { x: -100, y:  121, v: 301 }, Spectra6Color::Green),
+    (
+        ChromaColor {
+            x: -30,
+            y: -36,
+            v: 93,
+        },
+        Spectra6Color::Black,
+    ),
+    (
+        ChromaColor {
+            x: -42,
+            y: -13,
+            v: 451,
+        },
+        Spectra6Color::White,
+    ),
+    (
+        ChromaColor {
+            x: 239,
+            y: 402,
+            v: 450,
+        },
+        Spectra6Color::Yellow,
+    ),
+    (
+        ChromaColor {
+            x: 310,
+            y: 16,
+            v: 328,
+        },
+        Spectra6Color::Red,
+    ),
+    (
+        ChromaColor {
+            x: -268,
+            y: -195,
+            v: 369,
+        },
+        Spectra6Color::Blue,
+    ),
+    (
+        ChromaColor {
+            x: -100,
+            y: 121,
+            v: 301,
+        },
+        Spectra6Color::Green,
+    ),
 ];
 
 pub struct SpectraPacker<T>(pub T);
@@ -149,4 +191,3 @@ pub fn test_screen(width: usize, height: usize) -> impl Iterator<Item = Spectra6
         }
     })
 }
-

--- a/src/panic_mode.rs
+++ b/src/panic_mode.rs
@@ -198,7 +198,7 @@ fn force_led_on() {
 /// retry.
 pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
     let HardwareCtx {
-        mut rtc,
+        rtc,
         mut gpio_btn_refresh,
         mut gpio_btn_previous,
         mut gpio_btn_next,
@@ -260,10 +260,6 @@ pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
             esp_hal::rtc_cntl::sleep::WakeupLevel::Low,
         ),
     ];
-    let pin_wake_source = esp_hal::rtc_cntl::sleep::RtcioWakeupSource::new(wakeup_pins);
-    let wake_sources: &[&dyn esp_hal::rtc_cntl::sleep::WakeSource] = &[&pin_wake_source];
-
-    println!("Going to deep sleep after panic render (button-only wake)");
-    wait_for_tx_idle();
-    rtc.sleep_deep(wake_sources);
+    println!("Panic render done; deep-sleeping (button-only wake)");
+    crate::sleep::start_sleep(rtc, None, wakeup_pins);
 }

--- a/src/sleep.rs
+++ b/src/sleep.rs
@@ -1,0 +1,42 @@
+use crate::uart;
+use embassy_time::Instant;
+use esp_hal::peripherals::SENS;
+use esp_hal::rtc_cntl;
+use esp_println::println;
+use heapless::vec::Vec;
+
+pub fn start_sleep<'a>(
+    mut rtc: rtc_cntl::Rtc<'a>,
+    wakeup_requested: Option<Instant>,
+    wakeup_pins: &mut [(&mut dyn esp_hal::gpio::RtcPin, rtc_cntl::sleep::WakeupLevel)],
+) -> ! {
+    // Shut down ADC fully, see issue https://github.com/esp-rs/esp-hal/issues/2740
+    // Saves ~1.3 mA in deep sleep on ESP32-S3 (PPK2-measured on E1004).
+    SENS::regs()
+        .sar_power_xpd_sar()
+        .modify(|_, w| unsafe { w.force_xpd_sar().bits(0) });
+
+    let pin_wake_source = rtc_cntl::sleep::RtcioWakeupSource::new(wakeup_pins);
+    let timer_wake_source = wakeup_requested.map(|wakeup_requested| {
+        let remaining_time = wakeup_requested.saturating_duration_since(Instant::now());
+        // Need to convert embassy_time::Duration to core::time::Duration, do it by converting to
+        // and from microseconds
+        let remaining_time = core::time::Duration::from_micros(remaining_time.as_micros());
+        rtc_cntl::sleep::TimerWakeupSource::new(remaining_time)
+    });
+    let mut wake_sources: Vec<&dyn rtc_cntl::sleep::WakeSource, 2> = Vec::new();
+    // TODO: Remove unwraps
+    wake_sources
+        .push(&pin_wake_source)
+        .ok()
+        .expect("Unable to add pin wake source");
+    if let Some(timer_wake_source) = timer_wake_source.as_ref() {
+        wake_sources
+            .push(timer_wake_source)
+            .ok()
+            .expect("Unable to add timer wake source");
+    }
+    println!("Going to deep sleep");
+    uart::wait_for_tx_idle();
+    rtc.sleep_deep(wake_sources.as_slice());
+}

--- a/src/sy6974b.rs
+++ b/src/sy6974b.rs
@@ -12,7 +12,19 @@ use embedded_hal_async::i2c::I2c;
 use esp_println::println;
 
 const I2C_ADDR: u8 = 0x6B;
+const REG_INPUT_SOURCE: u8 = 0x00;
+const REG_CHARGE_TERM: u8 = 0x05;
 const REG_STATUS: u8 = 0x08;
+
+/// REG00 bit 7. When set, the charger ignores VBUS and the system rail
+/// runs entirely from BAT — USB-C can stay plugged in without feeding
+/// the system. Used by [`enter_measurement_mode`].
+const REG00_EN_HIZ: u8 = 1 << 7;
+
+/// REG05 bits 5:4 = WATCHDOG[1:0]. Default `01` (40 s); we mask these
+/// to `00` (timer disabled) so HIZ doesn't get reset back to default
+/// when the timer fires.
+const REG05_WATCHDOG_MASK: u8 = 0b0011_0000;
 
 /// What the charger thinks the system is doing right now.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -39,6 +51,70 @@ impl PowerStatus {
             PowerStatus::Fault => "fault",
         }
     }
+}
+
+/// Park the charger so a Nordic Power Profiler Kit II on the BAT pins
+/// sees the real system load even with USB-C still plugged in. Takes
+/// the bus by value and returns it so the caller doesn't need a `mut`
+/// binding when the cfg-gate behind which this is called is off.
+///
+/// Two writes, both read-modify-write so other bits keep their POR
+/// values:
+///
+/// 1. **REG05 WATCHDOG → 00 (disable).** Default is 40 s; on expiry
+///    the chip "gets back to the default mode" (datasheet § BATFET
+///    Control), which would clear EN_HIZ. Disable it first so it can't
+///    fire between the two writes.
+/// 2. **REG00 EN_HIZ → 1.** Input goes high-impedance, BAT supplies
+///    VSYS through the BATFET. CH340K stays alive on the separate
+///    USB-VBUS → TPL740F33 LDO rail (`UART_3V3`), independent of the
+///    charger, so `esptool` and the serial console keep working.
+///
+/// Both transactions log; on I²C failure the function returns the bus
+/// and the chip stays in whatever state it was in.
+pub async fn enter_measurement_mode<B: I2c>(mut i2c: B) -> B {
+    let mut reg05 = [0u8; 1];
+    if let Err(e) = i2c
+        .write_read(I2C_ADDR, &[REG_CHARGE_TERM], &mut reg05)
+        .await
+    {
+        println!("SY6974B REG05 read failed: {:?}", e);
+        return i2c;
+    }
+    let new_reg05 = reg05[0] & !REG05_WATCHDOG_MASK;
+    if let Err(e) = i2c
+        .write(I2C_ADDR, &[REG_CHARGE_TERM, new_reg05])
+        .await
+    {
+        println!("SY6974B REG05 write failed: {:?}", e);
+        return i2c;
+    }
+    println!(
+        "SY6974B watchdog disabled: REG05 0x{:02x} -> 0x{:02x}",
+        reg05[0], new_reg05
+    );
+
+    let mut reg00 = [0u8; 1];
+    if let Err(e) = i2c
+        .write_read(I2C_ADDR, &[REG_INPUT_SOURCE], &mut reg00)
+        .await
+    {
+        println!("SY6974B REG00 read failed: {:?}", e);
+        return i2c;
+    }
+    let new_reg00 = reg00[0] | REG00_EN_HIZ;
+    if let Err(e) = i2c
+        .write(I2C_ADDR, &[REG_INPUT_SOURCE, new_reg00])
+        .await
+    {
+        println!("SY6974B REG00 write failed: {:?}", e);
+        return i2c;
+    }
+    println!(
+        "SY6974B HIZ enabled: REG00 0x{:02x} -> 0x{:02x} (system on BAT only)",
+        reg00[0], new_reg00
+    );
+    i2c
 }
 
 /// Read the status register, decode, and return the high-level

--- a/src/sy6974b.rs
+++ b/src/sy6974b.rs
@@ -82,10 +82,7 @@ pub async fn enter_measurement_mode<B: I2c>(mut i2c: B) -> B {
         return i2c;
     }
     let new_reg05 = reg05[0] & !REG05_WATCHDOG_MASK;
-    if let Err(e) = i2c
-        .write(I2C_ADDR, &[REG_CHARGE_TERM, new_reg05])
-        .await
-    {
+    if let Err(e) = i2c.write(I2C_ADDR, &[REG_CHARGE_TERM, new_reg05]).await {
         println!("SY6974B REG05 write failed: {:?}", e);
         return i2c;
     }
@@ -103,10 +100,7 @@ pub async fn enter_measurement_mode<B: I2c>(mut i2c: B) -> B {
         return i2c;
     }
     let new_reg00 = reg00[0] | REG00_EN_HIZ;
-    if let Err(e) = i2c
-        .write(I2C_ADDR, &[REG_INPUT_SOURCE, new_reg00])
-        .await
-    {
+    if let Err(e) = i2c.write(I2C_ADDR, &[REG_INPUT_SOURCE, new_reg00]).await {
         println!("SY6974B REG00 write failed: {:?}", e);
         return i2c;
     }


### PR DESCRIPTION
## Summary
- Clears `SENS.sar_power_xpd_sar.force_xpd_sar` immediately before `rtc.sleep_deep(...)`, working around esp-rs/esp-hal#2740 (`Adc::new` sets the bit and never clears it). Drops the E1004 deep-sleep floor from **1.585 mA → ~250 µA** (PPK2-measured), ~6× lower.
- New `crate::sleep::start_sleep` helper centralises the SAR-XPD clear + wake-source plumbing. `normal_mode::run` and `panic_mode::run` both go through it instead of building wake sources and calling `rtc.sleep_deep` themselves; panic mode passes `None` for the timer to keep its button-only wake.
- `POWER.md` rewritten around the result and the daily-energy budget. Estimated battery life on the E1004's 5000 mAh cell at 1 refresh/day goes from ~120 days to **~575 days (~19 months)**.

Also folded in two earlier prep commits already on this branch: bench-feature rename `ppk2` → `disable_charger`, and a `cargo fmt` pass.

## Test plan
- [x] PPK2 measurement on E1004 confirms ~250 µA deep-sleep floor (down from 1.585 mA).
- [x] `cargo check` clean for `e1001`, `e1002`, `e1004` features.
- [x] Button + timer wake on E1004 verified post-refactor (user-reported "power measurements are still good").
- [ ] Smoke-test button wake on E1001 / E1002 (refactor is shared, but only bench-tested on E1004).
- [ ] Confirm panic-mode deep sleep still wakes on button press (now goes through the helper instead of hand-rolled `sleep_deep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)