### PR TITLE
WiFi fast reconnect: persist hint in NVS via WifiCredStore trait

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -25,7 +25,7 @@ extern crate alloc;
 
 use epd_photoframe::config::Config;
 use epd_photoframe::config_mode;
-use epd_photoframe::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction, WifiCredentials};
+use epd_photoframe::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction};
 use epd_photoframe::panel::{Panel, PanelColor};
 use epd_photoframe::panic_mode;
 
@@ -217,31 +217,25 @@ async fn main(spawner: Spawner) -> ! {
     // offset/size) or actual flash hardware trouble — panicking there is
     // the right call. A missing *key* is different: that's how we detect
     // "needs configuring" and short-circuit into config mode below.
-    let mut config =
+    let config =
         Config::new(peripherals.FLASH).expect("NVS init failed — check partition table and flash");
-    let creds = match (
-        config.wifi_ssid().ok().flatten(),
-        config.wifi_password().ok().flatten(),
-        config.image_url().ok().flatten(),
-    ) {
-        (Some(ssid), Some(password), Some(base_url)) => {
-            println!(
-                "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?}",
-                ssid,
-                password.len(),
-                base_url
-            );
-            Some(WifiCredentials {
-                ssid,
-                password,
-                base_url,
-            })
-        }
-        _ => {
-            println!("NVS config incomplete; forcing config mode");
-            None
-        }
-    };
+    if config.is_configured().unwrap_or(false) {
+        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
+        println!(
+            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
+            config.get_wifi_ssid().ok().flatten().as_deref().unwrap_or(""),
+            config
+                .get_wifi_password()
+                .ok()
+                .flatten()
+                .map(|p| p.len())
+                .unwrap_or(0),
+            config.get_image_url().ok().flatten().as_deref().unwrap_or(""),
+            if has_hint { "present" } else { "none" },
+        );
+    } else {
+        println!("NVS config incomplete; forcing config mode");
+    }
 
     let timg0 = TimerGroup::new(peripherals.TIMG0);
     let sw_ints =
@@ -383,7 +377,7 @@ async fn main(spawner: Spawner) -> ! {
     if let Some(panic_msg) = panic_mode::take_pending_message() {
         panic_mode::run(hw, panic_msg.as_str()).await
     } else {
-        run_normal_boot(hw, creds, config).await
+        run_normal_boot(hw, config).await
     }
 }
 
@@ -397,7 +391,6 @@ async fn main(spawner: Spawner) -> ! {
 /// implicitly only runs on the other arm".
 async fn run_normal_boot(
     mut hw: HardwareCtx,
-    creds: Option<WifiCredentials>,
     config: Config<'static>,
 ) -> ! {
     // Past the panic-render decision: any panic from here on is
@@ -449,7 +442,7 @@ async fn run_normal_boot(
     // we enter configuration mode. If either (or both) was never pressed,
     // `wait_for_high` resolves immediately because the pin is already high,
     // so normally this block completes in microseconds.
-    let entering_config_mode = creds.is_none() || {
+    let entering_config_mode = !config.is_configured().unwrap_or(false) || {
         let mut prev_input = Input::new(
             hw.gpio_btn_previous.reborrow(),
             InputConfig::default().with_pull(Pull::Up),
@@ -469,10 +462,8 @@ async fn run_normal_boot(
         )
     };
 
-    if let Some(creds) = creds
-        && !entering_config_mode
-    {
-        epd_photoframe::normal_mode::run(hw, creds).await
+    if !entering_config_mode {
+        epd_photoframe::normal_mode::run(hw, config).await
     } else {
         // Entering config mode is a deliberate reset of the device's
         // "what's displayed" state — whatever URL was committed last

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@
 //! for static-IP fields later (see `PLAN.md`).
 
 use alloc::string::String;
+use alloc::vec::Vec;
+use core::cell::RefCell;
 use esp_nvs::{Key, error::Error};
 
 /// ESP-IDF default NVS partition offset (see the project's partition table:
@@ -17,11 +19,22 @@ const NS: Key = Key::from_str("config");
 const K_WIFI_SSID: Key = Key::from_str("wifi.ssid");
 const K_WIFI_PASS: Key = Key::from_str("wifi.pass");
 const K_IMAGE_URL: Key = Key::from_str("image.url");
+/// Last-known BSSID + channel, stored as a 7-byte blob (6 bytes BSSID
+/// followed by 1 byte channel). Read on the next boot to pin the radio
+/// to that AP and skip the scan; cleared automatically whenever the
+/// SSID or password is rewritten so a credential change can't leave a
+/// stale hint behind.
+const K_WIFI_HINT: Key = Key::from_str("wifi.hint");
 
 /// Owns the flash peripheral and the parsed NVS state for the lifetime of
 /// the caller. Construct once at boot; re-use for reads and writes.
+///
+/// `RefCell` wraps the underlying [`esp_nvs::Nvs`] so callers can use
+/// `&self` getters/setters. Single-executor cooperative scheduling means
+/// there's no parallel access; borrows never span an await, so a
+/// `RefCell` panic is unreachable in practice.
 pub struct Config<'d> {
-    nvs: esp_nvs::Nvs<esp_storage::FlashStorage<'d>>,
+    nvs: RefCell<esp_nvs::Nvs<esp_storage::FlashStorage<'d>>>,
 }
 
 impl<'d> Config<'d> {
@@ -32,42 +45,74 @@ impl<'d> Config<'d> {
     pub fn new(flash: esp_hal::peripherals::FLASH<'d>) -> Result<Self, Error> {
         let storage = esp_storage::FlashStorage::new(flash);
         let nvs = esp_nvs::Nvs::new(NVS_OFFSET, NVS_SIZE, storage)?;
-        Ok(Self { nvs })
+        Ok(Self {
+            nvs: RefCell::new(nvs),
+        })
     }
 
     /// Read `key` as a `String`; returns `Ok(None)` for the common
     /// "namespace missing" / "key missing" cases (benign, happens on a
     /// device that's never been configured) and `Err` for real flash or
     /// corruption problems.
-    fn get_string(&mut self, key: &Key) -> Result<Option<String>, Error> {
-        match self.nvs.get(&NS, key) {
+    fn get_string(&self, key: &Key) -> Result<Option<String>, Error> {
+        match self.nvs.borrow_mut().get(&NS, key) {
             Ok(v) => Ok(Some(v)),
             Err(Error::NamespaceNotFound | Error::KeyNotFound) => Ok(None),
             Err(e) => Err(e),
         }
     }
 
-    pub fn wifi_ssid(&mut self) -> Result<Option<String>, Error> {
+    pub fn is_configured(&self) -> Result<bool, Error> {
+        Ok(self.get_wifi_ssid()?.is_some()
+            && self.get_wifi_password()?.is_some()
+            && self.get_image_url()?.is_some())
+    }
+
+    pub fn get_wifi_ssid(&self) -> Result<Option<String>, Error> {
         self.get_string(&K_WIFI_SSID)
     }
 
-    pub fn wifi_password(&mut self) -> Result<Option<String>, Error> {
+    pub fn get_wifi_password(&self) -> Result<Option<String>, Error> {
         self.get_string(&K_WIFI_PASS)
     }
 
-    pub fn image_url(&mut self) -> Result<Option<String>, Error> {
+    pub fn get_image_url(&self) -> Result<Option<String>, Error> {
         self.get_string(&K_IMAGE_URL)
     }
 
     pub fn set_wifi_ssid(&mut self, v: &str) -> Result<(), Error> {
-        self.nvs.set(&NS, &K_WIFI_SSID, v)
+        self.nvs.borrow_mut().set(&NS, &K_WIFI_SSID, v)?;
+        // The hint is tied to the credentials it was learned with;
+        // rewriting either of them invalidates it.
+        self.clear_wifi_hint()
     }
 
     pub fn set_wifi_password(&mut self, v: &str) -> Result<(), Error> {
-        self.nvs.set(&NS, &K_WIFI_PASS, v)
+        self.nvs.borrow_mut().set(&NS, &K_WIFI_PASS, v)?;
+        self.clear_wifi_hint()
     }
 
     pub fn set_image_url(&mut self, v: &str) -> Result<(), Error> {
-        self.nvs.set(&NS, &K_IMAGE_URL, v)
+        self.nvs.borrow_mut().set(&NS, &K_IMAGE_URL, v)
+    }
+
+    /// Read the cached connect hint as an opaque blob. Returns
+    /// `Ok(None)` when the slot is missing (fresh device or just
+    /// cleared after a credential rewrite). Decoding back into the
+    /// hint's logical fields lives at the WiFi layer.
+    pub fn get_wifi_hint(&self) -> Result<Option<Vec<u8>>, Error> {
+        match self.nvs.borrow_mut().get::<Vec<u8>>(&NS, &K_WIFI_HINT) {
+            Ok(v) => Ok(Some(v)),
+            Err(Error::NamespaceNotFound | Error::KeyNotFound) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    pub fn set_wifi_hint(&mut self, hint: &[u8]) -> Result<(), Error> {
+        self.nvs.borrow_mut().set(&NS, &K_WIFI_HINT, hint)
+    }
+
+    pub fn clear_wifi_hint(&mut self) -> Result<(), Error> {
+        self.nvs.borrow_mut().delete(&NS, &K_WIFI_HINT)
     }
 }

--- a/src/config_mode.rs
+++ b/src/config_mode.rs
@@ -47,10 +47,10 @@ pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
     // password gives the form a "keep existing" sentinel; otherwise
     // (brand-new device or prior open-network config) the field starts
     // empty and whatever the user submits gets saved as-is.
-    let stored_ssid = nvs.wifi_ssid().ok().flatten().unwrap_or_default();
-    let stored_url = nvs.image_url().ok().flatten().unwrap_or_default();
+    let stored_ssid = nvs.get_wifi_ssid().ok().flatten().unwrap_or_default();
+    let stored_url = nvs.get_image_url().ok().flatten().unwrap_or_default();
     let password_is_set = nvs
-        .wifi_password()
+        .get_wifi_password()
         .ok()
         .flatten()
         .is_some_and(|p| !p.is_empty());
@@ -152,10 +152,10 @@ pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
             if let Err(e) = nvs.set_image_url(&creds.url) {
                 println!("WARNING: failed to write image.url: {:?}", e);
             }
-            // Any cached BSSID/channel belonged to the *previous*
-            // SSID; if creds just changed it's stale, so drop it
-            // and let the next boot scan fresh.
-            crate::single_shot_wifi::clear_hint();
+            // Any cached BSSID/channel belonging to a prior network is
+            // dropped automatically by the SSID/password setters above;
+            // no separate invalidation step needed.
+            //
             // Give the HTTP response a moment to flush before we reboot.
             Timer::after(Duration::from_millis(500)).await;
         }

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -3,8 +3,6 @@
 //! needs to cfg-gate on the panel model or care about pin counts — they
 //! see the same `EpdPanel` alias and the same field set.
 
-use alloc::string::String;
-
 use embassy_executor::Spawner;
 use esp_hal::gpio::{AnyPin, Output};
 use esp_hal::spi::master::Spi;
@@ -123,12 +121,4 @@ pub struct HardwareCtx {
     /// Always populated — both E1002 and E1004 have the piezo on the
     /// same pin per Seeed's E10xx ESPHome reference.
     pub buzzer: Buzzer,
-}
-
-/// Credentials + URL for the normal flow. Deliberately split out of
-/// `HardwareCtx` because config mode doesn't need them.
-pub struct WifiCredentials {
-    pub ssid: String,
-    pub password: String,
-    pub base_url: String,
 }

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -18,8 +18,9 @@ use esp_println::println;
 
 use crate::battery;
 use crate::button::wait_for_press;
+use crate::config::Config;
 use crate::error_image;
-use crate::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction, WifiCredentials};
+use crate::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction};
 use crate::panel::{Panel, PanelColor};
 use crate::rtc_persisted::RtcPersisted;
 use crate::sht40;
@@ -170,7 +171,7 @@ impl From<String> for FetchError {
 /// white pre-flash that `main()`'s `run_normal_boot` may have kicked
 /// off, then deep-sleep waking on either the `Refresh:` interval (or
 /// the fallback timer) or a button press.
-pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
+pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
     let HardwareCtx {
         rtc,
         wake_action,
@@ -202,7 +203,7 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
     let current_url: String = CURRENT_URL
         .get()
         .map(|s| String::from(s.as_str()))
-        .unwrap_or_else(|| creds.base_url.clone());
+        .unwrap_or_else(|| config.get_image_url().ok().flatten().unwrap_or_default());
     let current_url: String = match wake_action {
         WakeAction::Timer => match REDIRECT_URL.take() {
             Some(r) => {
@@ -245,7 +246,7 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
     let fetch_result: Result<(Vec<u8>, Option<RefreshHint>), FetchError> = {
         let base_url_ref = current_url.as_str();
         let wifi_result =
-            single_shot_wifi::run(wifi, &creds, WIFI_LINK_TIMEOUT, |stack| async move {
+            single_shot_wifi::run(wifi, &mut config, WIFI_LINK_TIMEOUT, |stack| async move {
                 let battery_mv = BATTERY_MV.wait().await;
                 let battery_pct = battery::mv_to_percentage(battery_mv);
                 let temp_humidity = TEMP_HUMIDITY.wait().await;
@@ -285,7 +286,9 @@ pub async fn run(ctx: HardwareCtx, creds: WifiCredentials) -> ! {
             .await;
         match wifi_result {
             Ok(inner) => inner,
-            Err(e) => Err(FetchError::from(e.message(&creds.ssid))),
+            Err(e) => Err(FetchError::from(
+                e.message(&config.get_wifi_ssid().ok().flatten().unwrap_or_default()),
+            )),
         }
     };
 

--- a/src/single_shot_wifi.rs
+++ b/src/single_shot_wifi.rs
@@ -19,41 +19,60 @@
 //! - `NETWORK_RESOURCES`/`WIFI<'static>` are single-shot — they can
 //!   be given to this function exactly once per boot.
 
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use embassy_futures::select::{Either, select};
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::signal::Signal;
 use embassy_time::{Duration, Instant, Timer};
 use esp_println::println;
 
-use crate::hardware::WifiCredentials;
+use crate::config::Config;
 use crate::net_resources::NETWORK_RESOURCES;
-use crate::rtc_persisted::RtcPersisted;
 
 /// Cached BSSID + channel of the AP we last associated with. Pinning
 /// both at the next association lets the radio go straight to that
 /// channel and AP without scanning, shaving ~1–2 s off the connect
-/// phase. The slot is `take()`n at use, then re-`set()` on success.
-/// If the pinned attempt fails, `wifi_runner` retries once with a
-/// no-hint fallback config in the same session, so a stale hint
-/// only costs an extra connect-attempt's worth of time.
-/// `RtcPersisted`'s magic gate handles the cold-boot "all zeros =
-/// no hint" case.
-#[esp_hal::ram(unstable(rtc_slow, persistent))]
-static WIFI_HINT: RtcPersisted<WifiHint> = RtcPersisted::new();
-
-#[derive(Clone, Copy)]
-struct WifiHint {
+/// phase. Persisted as an opaque byte blob by the [`WifiCredStore`]
+/// alongside the credentials it was learned with: when those
+/// credentials are rewritten the store also drops the hint, so a
+/// stale one can't survive a network change. If the pinned attempt
+/// fails anyway (AP roamed channel or BSSID), `wifi_runner` retries
+/// once with a no-hint fallback config in the same session, so the
+/// worst case is one extra connect-attempt's worth of time.
+#[derive(Clone, Copy, Eq, PartialEq)]
+pub struct WifiHint {
     bssid: [u8; 6],
     channel: u8,
 }
 
-/// Drop any cached BSSID/channel. Call from `config_mode` when the
-/// stored WiFi credentials are written: a fresh SSID/password may
-/// belong to a different AP, in which case the previous hint would
-/// fail and force a fallback scan on every wake until the slot
-/// gets overwritten with a fresh hint anyway.
-pub fn clear_hint() {
-    WIFI_HINT.clear();
+/// Wire format for the persisted hint: 6 BSSID bytes followed by 1
+/// channel byte. The store sees only `Vec<u8>` so [`Config`] doesn't
+/// need to know what's inside — corruption recovery (wrong-length
+/// blob) lives on the decode side via `TryFrom`.
+impl From<WifiHint> for Vec<u8> {
+    fn from(h: WifiHint) -> Vec<u8> {
+        let mut v = Vec::with_capacity(7);
+        v.extend_from_slice(&h.bssid);
+        v.push(h.channel);
+        v
+    }
+}
+
+impl TryFrom<Vec<u8>> for WifiHint {
+    type Error = ();
+    fn try_from(b: Vec<u8>) -> Result<Self, ()> {
+        if b.len() != 7 {
+            return Err(());
+        }
+        let mut bssid = [0u8; 6];
+        bssid.copy_from_slice(&b[..6]);
+        Ok(WifiHint {
+            bssid,
+            channel: b[6],
+        })
+    }
 }
 
 #[derive(Debug)]
@@ -67,6 +86,13 @@ pub enum Error {
     /// The whole setup phase (connect + pause + DHCP) didn't finish
     /// within the supplied timeout.
     Timeout,
+    /// The credential store returned an error reading SSID / password
+    /// (flash trouble, malformed entry).
+    CredentialsError,
+    /// The credential store returned `None` for a required field
+    /// (SSID or password). `is_configured` should normally rule this
+    /// out before `run` is called.
+    EmptyCredentials,
 }
 
 impl Error {
@@ -79,6 +105,8 @@ impl Error {
             Error::Init(e) => format!("WiFi init failed: {:?}", e),
             Error::Connect(e) => format!("WiFi connect failed: {:?}\nSSID: {}", e, ssid),
             Error::Timeout => format!("WiFi setup timed out\nSSID: {}", ssid),
+            Error::CredentialsError => format!("WiFi credentials read failed"),
+            Error::EmptyCredentials => format!("WiFi credentials missing"),
         }
     }
 }
@@ -107,18 +135,60 @@ const POST_DISCONNECT_PAUSE: Duration = Duration::from_millis(500);
 /// signal just overwrites itself each time).
 type WifiStatus = Signal<NoopRawMutex, Result<(), esp_radio::wifi::WifiError>>;
 
+/// Abstraction over "the place WiFi credentials + the BSSID/channel
+/// hint live". Implemented by [`Config`] (the NVS-backed store) for
+/// the production path; the indirection keeps `single_shot_wifi`
+/// independent of the storage details and makes the connect path
+/// testable with a mock. The `WifiHint` ↔ byte conversion lives in
+/// the impl so the store sees only opaque bytes.
+pub trait WifiCredStore {
+    fn get_ssid(&self) -> Result<String, Error>;
+    fn get_password(&self) -> Result<String, Error>;
+    fn get_hint(&self) -> Result<Option<WifiHint>, Error>;
+    fn set_hint(&mut self, hint: WifiHint) -> Result<(), Error>;
+}
+
+impl<'a> WifiCredStore for Config<'a> {
+    fn get_ssid(&self) -> Result<String, Error> {
+        self.get_wifi_ssid()
+            .map_err(|_| Error::CredentialsError)?
+            .ok_or(Error::EmptyCredentials)
+    }
+    fn get_password(&self) -> Result<String, Error> {
+        self.get_wifi_password()
+            .map_err(|_| Error::CredentialsError)?
+            .ok_or(Error::EmptyCredentials)
+    }
+    fn get_hint(&self) -> Result<Option<WifiHint>, Error> {
+        // A wrong-length blob (corrupt entry, schema change) is
+        // treated as "no hint" rather than a hard error: the next
+        // successful connect overwrites it.
+        Ok(self
+            .get_wifi_hint()
+            .map_err(|_| Error::CredentialsError)?
+            .and_then(|bytes| WifiHint::try_from(bytes).ok()))
+    }
+    fn set_hint(&mut self, hint: WifiHint) -> Result<(), Error> {
+        // esp-nvs short-circuits when the stored bytes already match,
+        // so calling this every successful connect is fine.
+        self.set_wifi_hint(&Vec::from(hint))
+            .map_err(|_| Error::CredentialsError)
+    }
+}
+
 /// Bring up WiFi + embassy-net for one fetch cycle and run `f` with
 /// the live `Stack`. See the module docs for the lifecycle / timeout
 /// contract.
-pub async fn run<'d, T, Fut, F>(
+pub async fn run<'d, T, Fut, F, S>(
     wifi: esp_hal::peripherals::WIFI<'d>,
-    creds: &WifiCredentials,
+    creds: &mut S,
     connect_timeout: Duration,
     f: F,
 ) -> Result<T, Error>
 where
     F: FnOnce(embassy_net::Stack<'static>) -> Fut,
     Fut: core::future::Future<Output = T>,
+    S: WifiCredStore + ?Sized,
 {
     // Signal carrying the initial association outcome from
     // `wifi_runner` to `run_with_wifi`. Lives on the stack for the
@@ -134,22 +204,20 @@ where
     // --- Construct the controller. `ControllerConfig::initial_config`
     // starts the radio in station mode with the supplied credentials. ---
     //
-    // If we have a cached BSSID + channel from a prior successful
-    // association, pin them both for the *initial* attempt — the
-    // radio skips the scan and goes straight to that AP. Take()n out
-    // of the slot so a failed association doesn't lock us into
-    // retrying with a stale hint; a fresh one is written back after
-    // a successful connect.
+    // If the credential store has a cached BSSID + channel from a
+    // prior successful association, pin them both for the *initial*
+    // attempt — the radio skips the scan and goes straight to that AP.
     //
     // Build a no-hint fallback config in parallel: if the hint-pinned
     // attempt fails (AP changed channel/BSSID, or moved entirely), the
-    // runner reconfigures the controller with this and retries once,
-    // so a stale hint costs an extra connect-attempt's worth of time
-    // rather than a whole error-frame cycle.
-    let hint = WIFI_HINT.take();
+    // runner reconfigures the controller with it and retries once, so
+    // a stale hint costs an extra connect-attempt's worth of time
+    // rather than a whole error-frame cycle. A fresh hint is written
+    // back to the store after every successful connect.
+    let hint = creds.get_hint().ok().flatten();
     let base_sta_cfg = esp_radio::wifi::sta::StationConfig::default()
-        .with_ssid(creds.ssid.as_str())
-        .with_password(creds.password.as_str().into());
+        .with_ssid(creds.get_ssid()?.as_str())
+        .with_password(creds.get_password()?.as_str().into());
     let (initial_sta_cfg, fallback_config) = match hint {
         Some(h) => {
             println!(
@@ -180,10 +248,12 @@ where
 
     // Phases 1 (associate) through 3 (f) all run concurrently with
     // `wifi_runner`, which handles mid-session disconnects by
-    // reconnecting silently.
+    // reconnecting silently. Only `wifi_runner` borrows `creds`
+    // (to write the fresh hint after each successful connect), so
+    // the `&mut creds` doesn't conflict with `run_with_wifi`.
     match select(
         run_with_wifi(&status, interfaces, timeout, f),
-        wifi_runner(&status, controller, fallback_config),
+        wifi_runner(creds, &status, controller, fallback_config),
     )
     .await
     {
@@ -275,7 +345,8 @@ where
 /// The slot is `take()`n on each loop iteration so the fallback fires
 /// at most once per session even if a successful `Ok` re-arms the
 /// reconnect path.
-async fn wifi_runner<'d>(
+async fn wifi_runner<'d, S: WifiCredStore + ?Sized>(
+    creds: &mut S,
     status: &WifiStatus,
     mut controller: esp_radio::wifi::WifiController<'d>,
     mut fallback_config: Option<esp_radio::wifi::Config>,
@@ -295,10 +366,16 @@ async fn wifi_runner<'d>(
                             info.bssid[3], info.bssid[4], info.bssid[5],
                             info.channel
                         );
-                        WIFI_HINT.set(WifiHint {
+                        // We're already associated; a hint-write
+                        // failure is not worth dropping the connection
+                        // for — the worst case is the next boot does
+                        // a no-hint scan.
+                        if let Err(e) = creds.set_hint(WifiHint {
                             bssid: info.bssid,
                             channel: info.channel,
-                        });
+                        }) {
+                            println!("set_hint failed; not caching hint: {:?}", e);
+                        }
                     }
                     Err(e) => println!("ap_info() failed; not caching hint: {:?}", e),
                 }


### PR DESCRIPTION
## Summary
- Moves the BSSID/channel hint from RTC-slow RAM to NVS (alongside the credentials it was learned with), so even a fully power-cycled device boots into a fast reconnect.
- Introduces a `WifiCredStore` trait (impl on `Config<'_>`) that lets `single_shot_wifi` stay independent of the NVS layer and become testable; `WifiCredentials` is gone — `Config` is plumbed through `normal_mode::run` / `config_mode::run` directly.
- `set_wifi_ssid` / `set_wifi_password` auto-clear the hint, so a credential change can't leave a stale BSSID behind. esp-nvs short-circuits identical writes, so the per-connect "always set the hint" call is a no-op on the steady-state same-AP path.

## Test plan
- [ ] Flash on E1002, confirm initial cold-boot scans then subsequent wakes pin (boot log shows `wifi.hint=present`).
- [ ] Power-cycle the device fully; confirm the next boot still reconnects fast (hint survived flash).
- [ ] Enter config mode, change SSID, save; confirm next boot scans (hint cleared).
- [ ] Move device out of AP range / change router channel; confirm one slow cycle then recovery via the no-hint fallback already in `wifi_runner`.
- [ ] Flash on E1004 (and E1001 if available) to confirm device-feature parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)