### PR TITLE
WiFi fast reconnect: clear hint before credential write, only on change

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -81,15 +81,26 @@ impl<'d> Config<'d> {
     }
 
     pub fn set_wifi_ssid(&mut self, v: &str) -> Result<(), Error> {
-        self.nvs.borrow_mut().set(&NS, &K_WIFI_SSID, v)?;
         // The hint is tied to the credentials it was learned with;
-        // rewriting either of them invalidates it.
-        self.clear_wifi_hint()
+        // rewriting either of them invalidates it. Clear *before*
+        // writing the new value so a power cut between the two
+        // writes can't leave new creds paired with a stale hint —
+        // the safe intermediate state is "old SSID + no hint", which
+        // falls back cleanly to a scan on the next connect. Skip the
+        // work entirely when the SSID isn't actually changing.
+        if self.get_wifi_ssid()?.as_deref() != Some(v) {
+            self.clear_wifi_hint()?;
+        }
+        self.nvs.borrow_mut().set(&NS, &K_WIFI_SSID, v)
     }
 
     pub fn set_wifi_password(&mut self, v: &str) -> Result<(), Error> {
-        self.nvs.borrow_mut().set(&NS, &K_WIFI_PASS, v)?;
-        self.clear_wifi_hint()
+        // Same clear-before-write ordering and skip-if-unchanged as
+        // `set_wifi_ssid`; see that method for the rationale.
+        if self.get_wifi_password()?.as_deref() != Some(v) {
+            self.clear_wifi_hint()?;
+        }
+        self.nvs.borrow_mut().set(&NS, &K_WIFI_PASS, v)
     }
 
     pub fn set_image_url(&mut self, v: &str) -> Result<(), Error> {


### PR DESCRIPTION
## Summary
Picks up the two review comments from PR #8:

- **Order**: invalidate the hint *before* writing the new SSID/password. If a power cut hits between the two writes, the safe intermediate state is "old SSID + no hint" rather than "new SSID + stale hint" (which would attempt a pinned connect to a BSSID that no longer matches).
- **Skip when unchanged**: don't touch the hint slot if the new value equals the stored value. Re-saving identical creds from config mode is now a no-op for the hint.

## Test plan
- [ ] Save the same creds in config mode twice; confirm the hint persists across both saves (`wifi.hint=present` in the boot log).
- [ ] Save a different SSID; confirm the next boot shows `wifi.hint=none` and does a cold-scan.
- [ ] Same for changing the password without changing the SSID.

🤖 Generated with [Claude Code](https://claude.com/claude-code)