### PR TITLE
Replace device features with device binaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,15 +5,18 @@ rust-version = "1.91"
 version      = "0.1.0"
 
 [[bin]]
-name = "epd_photoframe"
-path = "./src/bin/main.rs"
+name = "e1001"
+path = "./src/bin/e1001.rs"
+
+[[bin]]
+name = "e1002"
+path = "./src/bin/e1002.rs"
+
+[[bin]]
+name = "e1004"
+path = "./src/bin/e1004.rs"
 
 [features]
-# Select exactly one device. Each device selects its panel driver and pinout.
-e1001 = [] # Seeed reTerminal E1001 (7", GDEY075T7 panel, 800x480 4-level grayscale)
-e1002 = [] # Seeed reTerminal E1002 (7", GDEP073E01 panel, 800x480)
-e1004 = [] # Seeed reTerminal E1004 (13", T133A01 panel, 1200x1600)
-
 # PPK2 bench-measurement mode (E1004 only). On boot, parks the SY6974B
 # charger in HIZ so the system rail runs entirely from the BAT input,
 # regardless of USB-C state. Intended for a Nordic Power Profiler Kit II

--- a/README.md
+++ b/README.md
@@ -26,17 +26,15 @@ Stretch goals:
 
 Supported devices
 -----------------
-Build with `cargo build --features <device>` (exactly one device feature
-must be enabled — there is no default):
+Build the binary for the device you want to flash:
 
-| Feature | Device      | Panel     | Resolution  | State       |
+| Binary  | Device      | Panel     | Resolution  | State       |
 |---------|-------------|-----------|-------------|-------------|
 | `e1001` | reTerminal E1001 (7")  | GDEY075T7  | 800×480 (4-level grayscale) | working    |
 | `e1002` | reTerminal E1002 (7")  | GDEP073E01 | 800×480  | working     |
 | `e1004` | reTerminal E1004 (13") | T133A01   | 1200×1600 | working     |
 
-All three panel driver modules are always compiled regardless of the
-selected feature, so changes surface compile errors in every driver.
+For example: `cargo build --bin e1002`.
 
 Progress
 --------

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,22 +2,167 @@
 //! concrete hardware context.
 
 use embassy_time::{Duration, Instant, Timer};
-use esp_hal::gpio::{Input, InputConfig, Pull};
+use esp_hal::clock::CpuClock;
+use esp_hal::gpio::{Input, InputConfig, Level, Output, OutputConfig, Pin, Pull};
+use esp_hal::timer::timg::TimerGroup;
 use esp_println::println;
 
 use crate::config::Config;
 use crate::config_mode;
-use crate::hardware::{HardwareCtx, WakeAction};
+use crate::hardware::{AppHardware, HardwareCtx, WakeAction};
 use crate::panel::{Panel, PanelColor};
 use crate::panic_mode;
 
-pub async fn run<P>(hw: HardwareCtx<P>, config: Config<'static>) -> !
+#[embassy_executor::task]
+async fn blink_task(mut led: Output<'static>) {
+    loop {
+        led.toggle();
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+pub fn init() -> esp_hal::peripherals::Peripherals {
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    esp_hal::init(config)
+}
+
+pub async fn run<P>(hw: AppHardware<P>) -> !
 where
     P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>> + 'static,
     P::Color: PanelColor + 'static,
     P::Error: core::fmt::Debug,
     P::InitMode: core::fmt::Debug,
 {
+    let button_bits = (1u32 << hw.gpio_btn_refresh.number())
+        | (1u32 << hw.gpio_btn_previous.number())
+        | (1u32 << hw.gpio_btn_next.number());
+    let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
+
+    let refresh_latched = (rtc_gpio_int_mask & (1u32 << hw.gpio_btn_refresh.number())) != 0;
+    let previous_latched = (rtc_gpio_int_mask & (1u32 << hw.gpio_btn_previous.number())) != 0;
+    let next_latched = (rtc_gpio_int_mask & (1u32 << hw.gpio_btn_next.number())) != 0;
+
+    let wake_action = determine_wake_action(
+        hw.reset_reason,
+        hw.wake_reason,
+        refresh_latched,
+        previous_latched,
+        next_latched,
+    );
+
+    let rtc = esp_hal::rtc_cntl::Rtc::new(hw.lpwr);
+    let time_since_boot = rtc.time_since_power_up();
+    println!(
+        "Device booting up - reset={:?} wake={:?} action={:?} \
+         latched[refresh={} previous={} next={}] \
+         uptime={time_since_boot:?}",
+        hw.reset_reason,
+        hw.wake_reason,
+        wake_action,
+        refresh_latched,
+        previous_latched,
+        next_latched,
+    );
+    println!(
+        "RTC CURRENT_URL: {:?}",
+        crate::normal_mode::CURRENT_URL.get().as_deref()
+    );
+    println!(
+        "RTC REDIRECT_URL: {:?}",
+        crate::normal_mode::REDIRECT_URL.get().as_deref()
+    );
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
+    esp_alloc::psram_allocator!(
+        hw.psram,
+        esp_hal::psram,
+        esp_hal::psram::PsramConfig {
+            mode: esp_hal::psram::PsramMode::OctalSpi,
+            ..Default::default()
+        }
+    );
+
+    let config = Config::new(hw.flash).expect("NVS init failed — check partition table and flash");
+    if config.is_configured().unwrap_or(false) {
+        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
+        println!(
+            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
+            config
+                .get_wifi_ssid()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
+            config
+                .get_wifi_password()
+                .ok()
+                .flatten()
+                .map(|p| p.len())
+                .unwrap_or(0),
+            config
+                .get_image_url()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
+            if has_hint { "present" } else { "none" },
+        );
+    } else {
+        println!("NVS config incomplete; forcing config mode");
+    }
+
+    let timg0 = TimerGroup::new(hw.timg0);
+    let sw_ints = esp_hal::interrupt::software::SoftwareInterruptControl::new(hw.sw_interrupt);
+    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+    hw.spawner.spawn(
+        blink_task(Output::new(
+            hw.status_led,
+            Level::Low,
+            OutputConfig::default(),
+        ))
+        .unwrap(),
+    );
+
+    let i2c0 = esp_hal::i2c::master::I2c::new(hw.i2c0, esp_hal::i2c::master::Config::default())
+        .unwrap()
+        .with_sda(hw.gpio_i2c_sda)
+        .with_scl(hw.gpio_i2c_scl)
+        .into_async();
+
+    #[cfg(feature = "disable_charger")]
+    let i2c0 = if hw.has_sy6974b {
+        crate::sy6974b::enter_measurement_mode(i2c0).await
+    } else {
+        i2c0
+    };
+
+    hw.spawner.spawn(
+        crate::normal_mode::sensor_task(
+            Output::new(hw.gpio_battery_enable, Level::Low, OutputConfig::default()),
+            hw.adc1,
+            hw.gpio_battery_sense,
+            i2c0,
+            hw.has_sy6974b,
+        )
+        .unwrap(),
+    );
+
+    let hw = HardwareCtx {
+        spawner: hw.spawner,
+        rtc,
+        wake_action,
+        wifi: hw.wifi,
+        refresh_button_label: hw.refresh_button_label,
+        has_sy6974b: hw.has_sy6974b,
+        gpio_btn_refresh: hw.gpio_btn_refresh,
+        gpio_btn_previous: hw.gpio_btn_previous,
+        gpio_btn_next: hw.gpio_btn_next,
+        spi_bus: hw.spi_bus,
+        epd: hw.epd,
+        buzzer: hw.buzzer,
+    };
+
     if let Some(panic_msg) = panic_mode::take_pending_message() {
         panic_mode::run(hw, panic_msg.as_str()).await
     } else {
@@ -91,7 +236,7 @@ where
     }
 }
 
-pub fn determine_wake_action(
+fn determine_wake_action(
     reset_reason: Option<esp_hal::rtc_cntl::SocResetReason>,
     wake_reason: esp_hal::system::SleepSource,
     refresh_latched: bool,
@@ -138,7 +283,7 @@ pub fn determine_wake_action(
     }
 }
 
-pub fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
+fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
     let rtc_io = esp_hal::peripherals::RTC_IO::regs();
     let value = rtc_io.rtc_gpio_status().read().int().bits() & mask;
     unsafe {

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,0 +1,150 @@
+//! Common firmware entry after a device-specific binary has built the
+//! concrete hardware context.
+
+use embassy_time::{Duration, Instant, Timer};
+use esp_hal::gpio::{Input, InputConfig, Pull};
+use esp_println::println;
+
+use crate::config::Config;
+use crate::config_mode;
+use crate::hardware::{HardwareCtx, WakeAction};
+use crate::panel::{Panel, PanelColor};
+use crate::panic_mode;
+
+pub async fn run<P>(hw: HardwareCtx<P>, config: Config<'static>) -> !
+where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>> + 'static,
+    P::Color: PanelColor + 'static,
+    P::Error: core::fmt::Debug,
+    P::InitMode: core::fmt::Debug,
+{
+    if let Some(panic_msg) = panic_mode::take_pending_message() {
+        panic_mode::run(hw, panic_msg.as_str()).await
+    } else {
+        run_normal_boot(hw, config).await
+    }
+}
+
+/// The non-panic boot path: flip the panic-reboot guard on, kick off
+/// the white pre-flash, run the config-mode hold race, and dispatch
+/// to either `normal_mode::run` (we have credentials and the user isn't
+/// holding both Previous + Next) or `config_mode::run`.
+async fn run_normal_boot<P>(mut hw: HardwareCtx<P>, config: Config<'static>) -> !
+where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>> + 'static,
+    P::Color: PanelColor + 'static,
+    P::Error: core::fmt::Debug,
+    P::InitMode: core::fmt::Debug,
+{
+    panic_mode::allow_reboot();
+
+    if hw.wake_action.show_white_flash() {
+        println!("White pre-flash");
+        hw.epd.enable().await.unwrap();
+        println!("Reset");
+        hw.epd.reset().await.unwrap();
+        println!("Wait until idle");
+        hw.epd.wait_until_idle().await.unwrap();
+        println!("Init");
+        let init_mode = P::init_mode_for_palette([P::Color::WHITE]);
+        hw.epd.init(&mut hw.spi_bus, init_mode).await.unwrap();
+        println!("Power on");
+        hw.epd.power_on(&mut hw.spi_bus).await.unwrap();
+        println!("Update frame (white)");
+        hw.epd
+            .update_frame(
+                &mut hw.spi_bus,
+                (0..(P::WIDTH * P::HEIGHT)).map(|_| P::Color::WHITE),
+            )
+            .await
+            .unwrap();
+        println!("Trigger refresh (no wait)");
+        hw.epd.display_frame_no_wait(&mut hw.spi_bus).await.unwrap();
+    }
+
+    let entering_config_mode = !config.is_configured().unwrap_or(false) || {
+        let mut prev_input = Input::new(
+            hw.gpio_btn_previous.reborrow(),
+            InputConfig::default().with_pull(Pull::Up),
+        );
+        let mut next_input = Input::new(
+            hw.gpio_btn_next.reborrow(),
+            InputConfig::default().with_pull(Pull::Up),
+        );
+        matches!(
+            embassy_futures::select::select3(
+                prev_input.wait_for_high(),
+                next_input.wait_for_high(),
+                Timer::at(Instant::MIN + Duration::from_secs(10)),
+            )
+            .await,
+            embassy_futures::select::Either3::Third(_)
+        )
+    };
+
+    if !entering_config_mode {
+        crate::normal_mode::run(hw, config).await
+    } else {
+        crate::normal_mode::CURRENT_URL.clear();
+        crate::normal_mode::REDIRECT_URL.clear();
+        config_mode::run(hw, config).await
+    }
+}
+
+pub fn determine_wake_action(
+    reset_reason: Option<esp_hal::rtc_cntl::SocResetReason>,
+    wake_reason: esp_hal::system::SleepSource,
+    refresh_latched: bool,
+    previous_latched: bool,
+    next_latched: bool,
+) -> WakeAction {
+    if reset_reason == Some(esp_hal::rtc_cntl::SocResetReason::CoreSw) {
+        if let Some(action) = crate::normal_mode::PENDING_ACTION.take() {
+            println!(
+                "Resuming with pending action {:?} from previous cycle",
+                action
+            );
+            return action;
+        }
+    } else {
+        crate::normal_mode::PENDING_ACTION.clear();
+    }
+
+    match wake_reason {
+        esp_hal::system::SleepSource::Undefined => WakeAction::FreshBoot,
+        esp_hal::system::SleepSource::Timer => WakeAction::Timer,
+        esp_hal::system::SleepSource::Gpio => {
+            if refresh_latched {
+                WakeAction::Refresh
+            } else if next_latched {
+                WakeAction::Next
+            } else if previous_latched {
+                WakeAction::Previous
+            } else {
+                println!(
+                    "WARNING: Gpio wake with no button bit latched; \
+                     defaulting to Refresh"
+                );
+                WakeAction::Refresh
+            }
+        }
+        other => {
+            println!(
+                "WARNING: unexpected wake reason {:?}; treating as fresh boot",
+                other
+            );
+            WakeAction::FreshBoot
+        }
+    }
+}
+
+pub fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
+    let rtc_io = esp_hal::peripherals::RTC_IO::regs();
+    let value = rtc_io.rtc_gpio_status().read().int().bits() & mask;
+    unsafe {
+        rtc_io
+            .rtc_gpio_status_w1tc()
+            .write(|w| w.rtc_gpio_status_int_w1tc().bits(mask));
+    }
+    value
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,9 +7,10 @@ use esp_hal::gpio::{Input, InputConfig, Level, Output, OutputConfig, Pin, Pull};
 use esp_hal::timer::timg::TimerGroup;
 use esp_println::println;
 
+use crate::buzzer::Buzzer;
 use crate::config::Config;
 use crate::config_mode;
-use crate::hardware::{AppHardware, HardwareCtx, WakeAction};
+use crate::hardware::{HardwareCtx, WakeAction};
 use crate::panel::{Panel, PanelColor};
 use crate::panic_mode;
 
@@ -26,147 +27,187 @@ pub fn init() -> esp_hal::peripherals::Peripherals {
     esp_hal::init(config)
 }
 
-pub async fn run<P>(hw: AppHardware<P>) -> !
+/// App startup object built by the selected device binary.
+pub struct App<P> {
+    pub spawner: embassy_executor::Spawner,
+    pub reset_reason: Option<esp_hal::rtc_cntl::SocResetReason>,
+    pub wake_reason: esp_hal::system::SleepSource,
+    pub wifi: esp_hal::peripherals::WIFI<'static>,
+    pub flash: esp_hal::peripherals::FLASH<'static>,
+    pub psram: esp_hal::peripherals::PSRAM<'static>,
+    pub lpwr: esp_hal::peripherals::LPWR<'static>,
+    pub timg0: esp_hal::peripherals::TIMG0<'static>,
+    pub sw_interrupt: esp_hal::peripherals::SW_INTERRUPT<'static>,
+    pub status_led: esp_hal::gpio::AnyPin<'static>,
+    pub refresh_button_label: &'static str,
+    pub has_sy6974b: bool,
+
+    pub i2c0: esp_hal::peripherals::I2C0<'static>,
+    pub gpio_i2c_sda: esp_hal::peripherals::GPIO19<'static>,
+    pub gpio_i2c_scl: esp_hal::peripherals::GPIO20<'static>,
+    pub adc1: esp_hal::peripherals::ADC1<'static>,
+    pub gpio_battery_enable: esp_hal::peripherals::GPIO21<'static>,
+    pub gpio_battery_sense: esp_hal::peripherals::GPIO1<'static>,
+
+    pub gpio_btn_refresh: esp_hal::gpio::AnyPin<'static>,
+    pub gpio_btn_previous: esp_hal::gpio::AnyPin<'static>,
+    pub gpio_btn_next: esp_hal::gpio::AnyPin<'static>,
+
+    pub spi_bus: esp_hal::spi::master::Spi<'static, esp_hal::Async>,
+    pub epd: P,
+    pub buzzer: Buzzer,
+}
+
+impl<P> App<P>
 where
     P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>> + 'static,
     P::Color: PanelColor + 'static,
     P::Error: core::fmt::Debug,
     P::InitMode: core::fmt::Debug,
 {
-    let button_bits = (1u32 << hw.gpio_btn_refresh.number())
-        | (1u32 << hw.gpio_btn_previous.number())
-        | (1u32 << hw.gpio_btn_next.number());
-    let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
+    pub async fn run(self) -> ! {
+        let button_bits = (1u32 << self.gpio_btn_refresh.number())
+            | (1u32 << self.gpio_btn_previous.number())
+            | (1u32 << self.gpio_btn_next.number());
+        let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
 
-    let refresh_latched = (rtc_gpio_int_mask & (1u32 << hw.gpio_btn_refresh.number())) != 0;
-    let previous_latched = (rtc_gpio_int_mask & (1u32 << hw.gpio_btn_previous.number())) != 0;
-    let next_latched = (rtc_gpio_int_mask & (1u32 << hw.gpio_btn_next.number())) != 0;
+        let refresh_latched = (rtc_gpio_int_mask & (1u32 << self.gpio_btn_refresh.number())) != 0;
+        let previous_latched = (rtc_gpio_int_mask & (1u32 << self.gpio_btn_previous.number())) != 0;
+        let next_latched = (rtc_gpio_int_mask & (1u32 << self.gpio_btn_next.number())) != 0;
 
-    let wake_action = determine_wake_action(
-        hw.reset_reason,
-        hw.wake_reason,
-        refresh_latched,
-        previous_latched,
-        next_latched,
-    );
+        let wake_action = determine_wake_action(
+            self.reset_reason,
+            self.wake_reason,
+            refresh_latched,
+            previous_latched,
+            next_latched,
+        );
 
-    let rtc = esp_hal::rtc_cntl::Rtc::new(hw.lpwr);
-    let time_since_boot = rtc.time_since_power_up();
-    println!(
-        "Device booting up - reset={:?} wake={:?} action={:?} \
+        let rtc = esp_hal::rtc_cntl::Rtc::new(self.lpwr);
+        let time_since_boot = rtc.time_since_power_up();
+        println!(
+            "Device booting up - reset={:?} wake={:?} action={:?} \
          latched[refresh={} previous={} next={}] \
          uptime={time_since_boot:?}",
-        hw.reset_reason,
-        hw.wake_reason,
-        wake_action,
-        refresh_latched,
-        previous_latched,
-        next_latched,
-    );
-    println!(
-        "RTC CURRENT_URL: {:?}",
-        crate::normal_mode::CURRENT_URL.get().as_deref()
-    );
-    println!(
-        "RTC REDIRECT_URL: {:?}",
-        crate::normal_mode::REDIRECT_URL.get().as_deref()
-    );
-
-    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
-    esp_alloc::psram_allocator!(
-        hw.psram,
-        esp_hal::psram,
-        esp_hal::psram::PsramConfig {
-            mode: esp_hal::psram::PsramMode::OctalSpi,
-            ..Default::default()
-        }
-    );
-
-    let config = Config::new(hw.flash).expect("NVS init failed — check partition table and flash");
-    if config.is_configured().unwrap_or(false) {
-        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
-        println!(
-            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
-            config
-                .get_wifi_ssid()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            config
-                .get_wifi_password()
-                .ok()
-                .flatten()
-                .map(|p| p.len())
-                .unwrap_or(0),
-            config
-                .get_image_url()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            if has_hint { "present" } else { "none" },
+            self.reset_reason,
+            self.wake_reason,
+            wake_action,
+            refresh_latched,
+            previous_latched,
+            next_latched,
         );
-    } else {
-        println!("NVS config incomplete; forcing config mode");
-    }
+        println!(
+            "RTC CURRENT_URL: {:?}",
+            crate::normal_mode::CURRENT_URL.get().as_deref()
+        );
+        println!(
+            "RTC REDIRECT_URL: {:?}",
+            crate::normal_mode::REDIRECT_URL.get().as_deref()
+        );
 
-    let timg0 = TimerGroup::new(hw.timg0);
-    let sw_ints = esp_hal::interrupt::software::SoftwareInterruptControl::new(hw.sw_interrupt);
-    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+        esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
+        esp_alloc::psram_allocator!(
+            self.psram,
+            esp_hal::psram,
+            esp_hal::psram::PsramConfig {
+                mode: esp_hal::psram::PsramMode::OctalSpi,
+                ..Default::default()
+            }
+        );
 
-    hw.spawner.spawn(
-        blink_task(Output::new(
-            hw.status_led,
-            Level::Low,
-            OutputConfig::default(),
-        ))
-        .unwrap(),
-    );
+        let config =
+            Config::new(self.flash).expect("NVS init failed — check partition table and flash");
+        if config.is_configured().unwrap_or(false) {
+            let has_hint = config.get_wifi_hint().ok().flatten().is_some();
+            println!(
+                "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
+                config
+                    .get_wifi_ssid()
+                    .ok()
+                    .flatten()
+                    .as_deref()
+                    .unwrap_or(""),
+                config
+                    .get_wifi_password()
+                    .ok()
+                    .flatten()
+                    .map(|p| p.len())
+                    .unwrap_or(0),
+                config
+                    .get_image_url()
+                    .ok()
+                    .flatten()
+                    .as_deref()
+                    .unwrap_or(""),
+                if has_hint { "present" } else { "none" },
+            );
+        } else {
+            println!("NVS config incomplete; forcing config mode");
+        }
 
-    let i2c0 = esp_hal::i2c::master::I2c::new(hw.i2c0, esp_hal::i2c::master::Config::default())
-        .unwrap()
-        .with_sda(hw.gpio_i2c_sda)
-        .with_scl(hw.gpio_i2c_scl)
-        .into_async();
+        let timg0 = TimerGroup::new(self.timg0);
+        let sw_ints =
+            esp_hal::interrupt::software::SoftwareInterruptControl::new(self.sw_interrupt);
+        esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
 
-    #[cfg(feature = "disable_charger")]
-    let i2c0 = if hw.has_sy6974b {
-        crate::sy6974b::enter_measurement_mode(i2c0).await
-    } else {
-        i2c0
-    };
+        self.spawner.spawn(
+            blink_task(Output::new(
+                self.status_led,
+                Level::Low,
+                OutputConfig::default(),
+            ))
+            .unwrap(),
+        );
 
-    hw.spawner.spawn(
-        crate::normal_mode::sensor_task(
-            Output::new(hw.gpio_battery_enable, Level::Low, OutputConfig::default()),
-            hw.adc1,
-            hw.gpio_battery_sense,
-            i2c0,
-            hw.has_sy6974b,
-        )
-        .unwrap(),
-    );
+        let i2c0 =
+            esp_hal::i2c::master::I2c::new(self.i2c0, esp_hal::i2c::master::Config::default())
+                .unwrap()
+                .with_sda(self.gpio_i2c_sda)
+                .with_scl(self.gpio_i2c_scl)
+                .into_async();
 
-    let hw = HardwareCtx {
-        spawner: hw.spawner,
-        rtc,
-        wake_action,
-        wifi: hw.wifi,
-        refresh_button_label: hw.refresh_button_label,
-        has_sy6974b: hw.has_sy6974b,
-        gpio_btn_refresh: hw.gpio_btn_refresh,
-        gpio_btn_previous: hw.gpio_btn_previous,
-        gpio_btn_next: hw.gpio_btn_next,
-        spi_bus: hw.spi_bus,
-        epd: hw.epd,
-        buzzer: hw.buzzer,
-    };
+        #[cfg(feature = "disable_charger")]
+        let i2c0 = if self.has_sy6974b {
+            crate::sy6974b::enter_measurement_mode(i2c0).await
+        } else {
+            i2c0
+        };
 
-    if let Some(panic_msg) = panic_mode::take_pending_message() {
-        panic_mode::run(hw, panic_msg.as_str()).await
-    } else {
-        run_normal_boot(hw, config).await
+        self.spawner.spawn(
+            crate::normal_mode::sensor_task(
+                Output::new(
+                    self.gpio_battery_enable,
+                    Level::Low,
+                    OutputConfig::default(),
+                ),
+                self.adc1,
+                self.gpio_battery_sense,
+                i2c0,
+                self.has_sy6974b,
+            )
+            .unwrap(),
+        );
+
+        let hw = HardwareCtx {
+            spawner: self.spawner,
+            rtc,
+            wake_action,
+            wifi: self.wifi,
+            refresh_button_label: self.refresh_button_label,
+            has_sy6974b: self.has_sy6974b,
+            gpio_btn_refresh: self.gpio_btn_refresh,
+            gpio_btn_previous: self.gpio_btn_previous,
+            gpio_btn_next: self.gpio_btn_next,
+            spi_bus: self.spi_bus,
+            epd: self.epd,
+            buzzer: self.buzzer,
+        };
+
+        if let Some(panic_msg) = panic_mode::take_pending_message() {
+            panic_mode::run(hw, panic_msg.as_str()).await
+        } else {
+            run_normal_boot(hw, config).await
+        }
     }
 }
 

--- a/src/bin/e1001.rs
+++ b/src/bin/e1001.rs
@@ -7,194 +7,29 @@
 )]
 
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use esp_hal::clock::CpuClock;
-use esp_hal::timer::timg::TimerGroup;
-
-use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
-use esp_hal::gpio::{Level, Output, OutputConfig};
-use esp_println::println;
-
+use esp_hal::gpio::{Input, InputConfig, Level, Output, OutputConfig, Pin, Pull};
 use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
 
 extern crate alloc;
 
-use epd_photoframe::config::Config;
-use epd_photoframe::hardware::HardwareCtx;
+use epd_photoframe::hardware::AppHardware;
 use epd_photoframe::panel::gdey075t7::Gdey075t7;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
 // For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
 esp_bootloader_esp_idf::esp_app_desc!();
 
-/// Read the RTC-IO interrupt status register (the wake latch) masked to the
-/// caller's bits of interest, clear those same bits via the register's
-/// write-1-to-clear sibling, and return the pre-clear masked value. Other
-/// bits in the register are neither read back nor touched.
-///
-/// Wraps the single `unsafe` the PAC mandates for this register: svd2rust
-/// marks `RTC_GPIO_STATUS_W1TC` with `Safety = Unsafe` because it can't
-/// statically verify field-value semantics, but writing any `u32` mask to
-/// a write-1-to-clear status register only flips hardware status bits in
-/// the RTC domain and cannot violate memory safety.
-fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
-    let rtc_io = esp_hal::peripherals::RTC_IO::regs();
-    let value = rtc_io.rtc_gpio_status().read().int().bits() & mask;
-    unsafe {
-        rtc_io
-            .rtc_gpio_status_w1tc()
-            .write(|w| w.rtc_gpio_status_int_w1tc().bits(mask));
-    }
-    value
-}
-
-#[embassy_executor::task]
-async fn blink_task(mut led: Output<'static>) {
-    loop {
-        led.toggle();
-        Timer::after(Duration::from_millis(500)).await;
-    }
-}
-
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let reset_reason = esp_hal::rtc_cntl::reset_reason(esp_hal::system::Cpu::ProCpu);
     let wake_reason = esp_hal::rtc_cntl::wakeup_cause();
-    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
-    let peripherals = esp_hal::init(config);
+    let peripherals = epd_photoframe::app::init();
 
-    // Bind semantic button names to the device-specific GPIOs. This is the
-    // only place where the silkscreen-to-GPIO mapping appears; everything
-    // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
-    // the rest of main() is device-agnostic. E1001 inherits the E1002
-    // mapping (same hardware aside from the panel).
     let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next) =
         (peripherals.GPIO3, peripherals.GPIO5, peripherals.GPIO4);
 
-    // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
-    // and clear it immediately so stale bits don't carry into the next cycle.
-    // The latch is authoritative because it captures the pin state at the
-    // exact moment of wake — even a sub-millisecond tap is recorded.
-    let button_bits = (1u32 << gpio_btn_refresh.number())
-        | (1u32 << gpio_btn_previous.number())
-        | (1u32 << gpio_btn_next.number());
-    let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
-
-    let refresh_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_refresh.number())) != 0;
-    let previous_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_previous.number())) != 0;
-    let next_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_next.number())) != 0;
-
-    let wake_action = epd_photoframe::app::determine_wake_action(
-        reset_reason,
-        wake_reason,
-        refresh_latched,
-        previous_latched,
-        next_latched,
-    );
-
-    let rtc = esp_hal::rtc_cntl::Rtc::new(peripherals.LPWR);
-    let time_since_boot = rtc.time_since_power_up();
-    println!(
-        "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
-         latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
-         uptime={time_since_boot:?}"
-    );
-    println!(
-        "RTC CURRENT_URL: {:?}",
-        epd_photoframe::normal_mode::CURRENT_URL.get().as_deref()
-    );
-    println!(
-        "RTC REDIRECT_URL: {:?}",
-        epd_photoframe::normal_mode::REDIRECT_URL.get().as_deref()
-    );
-
-    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
-    esp_alloc::psram_allocator!(
-        peripherals.PSRAM,
-        esp_hal::psram,
-        esp_hal::psram::PsramConfig {
-            mode: esp_hal::psram::PsramMode::OctalSpi,
-            ..Default::default()
-        }
-    );
-
-    // Load runtime configuration from NVS. A fresh / blank partition is
-    // not an error (esp-nvs treats all-0xFF as "no entries yet"), so the
-    // only ways `Config::new` fails are programming bugs (wrong partition
-    // offset/size) or actual flash hardware trouble — panicking there is
-    // the right call. A missing *key* is different: that's how we detect
-    // "needs configuring" and short-circuit into config mode below.
-    let config =
-        Config::new(peripherals.FLASH).expect("NVS init failed — check partition table and flash");
-    if config.is_configured().unwrap_or(false) {
-        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
-        println!(
-            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
-            config
-                .get_wifi_ssid()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            config
-                .get_wifi_password()
-                .ok()
-                .flatten()
-                .map(|p| p.len())
-                .unwrap_or(0),
-            config
-                .get_image_url()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            if has_hint { "present" } else { "none" },
-        );
-    } else {
-        println!("NVS config incomplete; forcing config mode");
-    }
-
-    let timg0 = TimerGroup::new(peripherals.TIMG0);
-    let sw_ints =
-        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
-
-    // Status LED is on a different GPIO per device.
-    let led_pin = peripherals.GPIO6;
-    spawner.spawn(blink_task(Output::new(led_pin, Level::Low, OutputConfig::default())).unwrap());
-
-    // One task that drives both per-wake sensor reads (battery ADC +
-    // SHT40 over I²C0) concurrently via `join`. By the time the URL
-    // is being built in `normal_mode::run`, both signals have been
-    // populated — the 10 ms ADC settle + the 10 ms SHT40 conversion
-    // happen alongside the ~1.3 s WiFi association, so the `wait()`s
-    // are essentially free.
-    let i2c0 =
-        esp_hal::i2c::master::I2c::new(peripherals.I2C0, esp_hal::i2c::master::Config::default())
-            .unwrap()
-            .with_sda(peripherals.GPIO19)
-            .with_scl(peripherals.GPIO20)
-            .into_async();
-
-    // PPK2 measurement mode: park the SY6974B charger in HIZ before
-    // anything else runs so the system rail spends as little time as
-    // possible drawing through VBUS. This must happen after I²C0 is up
-    // (the chip lives on this bus) but before any code that depends on
-    // the BAT-only power path being established.
-    spawner.spawn(
-        epd_photoframe::normal_mode::sensor_task(
-            Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
-            peripherals.ADC1,
-            peripherals.GPIO1,
-            i2c0,
-            false,
-        )
-        .unwrap(),
-    );
-
-    // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
     let epd_spi_bus = Spi::new(
         peripherals.SPI2,
         SpiConfig::default()
@@ -220,39 +55,31 @@ async fn main(spawner: Spawner) -> ! {
         Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
     );
 
-    // Unified hardware context handed off to whichever top-level flow
-    // wins (`panic_mode::run`, `run_normal_boot`, then `normal_mode::run`
-    // or `config_mode::run`). The panel's board-level enable rail
-    // (E1004's TFT_EN; no-op on E1002 / E1001) stays *off* here —
-    // each flow asserts it (idempotently) before its own first panel
-    // I/O, so the rail is only powered when the panel is about to be
-    // touched.
-    let hw = HardwareCtx {
+    epd_photoframe::app::run(AppHardware {
         spawner,
-        rtc,
-        wake_action,
+        reset_reason,
+        wake_reason,
         wifi: peripherals.WIFI,
+        flash: peripherals.FLASH,
+        psram: peripherals.PSRAM,
+        lpwr: peripherals.LPWR,
+        timg0: peripherals.TIMG0,
+        sw_interrupt: peripherals.SW_INTERRUPT,
+        status_led: peripherals.GPIO6.degrade(),
         refresh_button_label: "Refresh button (green)",
         has_sy6974b: false,
+        i2c0: peripherals.I2C0,
+        gpio_i2c_sda: peripherals.GPIO19,
+        gpio_i2c_scl: peripherals.GPIO20,
+        adc1: peripherals.ADC1,
+        gpio_battery_enable: peripherals.GPIO21,
+        gpio_battery_sense: peripherals.GPIO1,
         gpio_btn_refresh: gpio_btn_refresh.degrade(),
         gpio_btn_previous: gpio_btn_previous.degrade(),
         gpio_btn_next: gpio_btn_next.degrade(),
         spi_bus: epd_spi_bus,
         epd,
         buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
-    };
-
-    // --- Panic-render fast path -----------------------------------------
-    //
-    // If the previous boot ended in a panic, the release-build panic
-    // handler stashed the formatted message in `panic_mode::PANIC_MSG`
-    // and soft-reset. `take_pending_message` clears the slot, so a
-    // re-panic during render falls back to a normal cycle on the next
-    // boot rather than looping. Skips white pre-flash, WiFi, sensors,
-    // and the config-mode race: just renders the message and deep-
-    // sleeps, wakeable by timer or button so the user can retry
-    // without a power-cycle. The `else` branch holds the rest of
-    // `main()` so the divergence is structural — once we go into
-    // `panic_mode::run` we never come back.
-    epd_photoframe::app::run(hw, config).await
+    })
+    .await
 }

--- a/src/bin/e1001.rs
+++ b/src/bin/e1001.rs
@@ -14,7 +14,7 @@ use esp_hal::spi::master::Spi;
 
 extern crate alloc;
 
-use epd_photoframe::hardware::AppHardware;
+use epd_photoframe::app::App;
 use epd_photoframe::panel::gdey075t7::Gdey075t7;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
@@ -55,7 +55,7 @@ async fn main(spawner: Spawner) -> ! {
         Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
     );
 
-    epd_photoframe::app::run(AppHardware {
+    App {
         spawner,
         reset_reason,
         wake_reason,
@@ -80,6 +80,7 @@ async fn main(spawner: Spawner) -> ! {
         spi_bus: epd_spi_bus,
         epd,
         buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
-    })
+    }
+    .run()
     .await
 }

--- a/src/bin/e1001.rs
+++ b/src/bin/e1001.rs
@@ -7,7 +7,7 @@
 )]
 
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Instant, Timer};
+use embassy_time::{Duration, Timer};
 use esp_hal::clock::CpuClock;
 use esp_hal::timer::timg::TimerGroup;
 
@@ -19,22 +19,11 @@ use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
 
-use esp_hal::system::SleepSource;
-
 extern crate alloc;
 
 use epd_photoframe::config::Config;
-use epd_photoframe::config_mode;
-use epd_photoframe::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction};
-use epd_photoframe::panel::{Panel, PanelColor};
-use epd_photoframe::panic_mode;
-
-#[cfg(feature = "e1002")]
-use epd_photoframe::panel::gdep073e01::Gdep073e01;
-#[cfg(feature = "e1001")]
+use epd_photoframe::hardware::HardwareCtx;
 use epd_photoframe::panel::gdey075t7::Gdey075t7;
-#[cfg(feature = "e1004")]
-use epd_photoframe::panel::t133a01::T133A01;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
 // For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
@@ -61,61 +50,6 @@ fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
     value
 }
 
-fn determine_wake_action(
-    reset_reason: Option<esp_hal::rtc_cntl::SocResetReason>,
-    wake_reason: SleepSource,
-    refresh_latched: bool,
-    previous_latched: bool,
-    next_latched: bool,
-) -> WakeAction {
-    // A `CoreSw` reset paired with a populated `PENDING_ACTION` slot is
-    // the abort-during-refresh handoff from `normal_mode::run`. Honour
-    // it and short-circuit. Any other reset reason clears the slot so a
-    // value left behind by a previous abort can't leak through if the
-    // following soft reset never happened (e.g. brownout / watchdog).
-    if reset_reason == Some(esp_hal::rtc_cntl::SocResetReason::CoreSw) {
-        if let Some(action) = epd_photoframe::normal_mode::PENDING_ACTION.take() {
-            println!(
-                "Resuming with pending action {:?} from previous cycle",
-                action
-            );
-            return action;
-        }
-    } else {
-        epd_photoframe::normal_mode::PENDING_ACTION.clear();
-    }
-
-    match wake_reason {
-        SleepSource::Undefined => WakeAction::FreshBoot,
-        SleepSource::Timer => WakeAction::Timer,
-        // `RtcioWakeupSource` on the ESP32-S3 reports as `Gpio`. The
-        // RTC-IO interrupt latch authoritatively tells us which button(s)
-        // triggered the wake, even if the user has already released.
-        SleepSource::Gpio => {
-            if refresh_latched {
-                WakeAction::Refresh
-            } else if next_latched {
-                WakeAction::Next
-            } else if previous_latched {
-                WakeAction::Previous
-            } else {
-                println!(
-                    "WARNING: Gpio wake with no button bit latched; \
-                     defaulting to Refresh"
-                );
-                WakeAction::Refresh
-            }
-        }
-        other => {
-            println!(
-                "WARNING: unexpected wake reason {:?}; treating as fresh boot",
-                other
-            );
-            WakeAction::FreshBoot
-        }
-    }
-}
-
 #[embassy_executor::task]
 async fn blink_task(mut led: Output<'static>) {
     loop {
@@ -136,12 +70,8 @@ async fn main(spawner: Spawner) -> ! {
     // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
     // the rest of main() is device-agnostic. E1001 inherits the E1002
     // mapping (same hardware aside from the panel).
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
     let (mut gpio_btn_refresh, mut gpio_btn_previous, mut gpio_btn_next) =
         (peripherals.GPIO3, peripherals.GPIO5, peripherals.GPIO4);
-    #[cfg(feature = "e1004")]
-    let (mut gpio_btn_refresh, mut gpio_btn_previous, mut gpio_btn_next) =
-        (peripherals.GPIO5, peripherals.GPIO4, peripherals.GPIO3);
 
     // Read all three buttons ASAP so we capture the press even if the user
     // releases quickly after powering the device out of deep sleep.
@@ -176,7 +106,7 @@ async fn main(spawner: Spawner) -> ! {
     let previous_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_previous.number())) != 0;
     let next_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_next.number())) != 0;
 
-    let wake_action = determine_wake_action(
+    let wake_action = epd_photoframe::app::determine_wake_action(
         reset_reason,
         wake_reason,
         refresh_latched,
@@ -223,14 +153,24 @@ async fn main(spawner: Spawner) -> ! {
         let has_hint = config.get_wifi_hint().ok().flatten().is_some();
         println!(
             "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
-            config.get_wifi_ssid().ok().flatten().as_deref().unwrap_or(""),
+            config
+                .get_wifi_ssid()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
             config
                 .get_wifi_password()
                 .ok()
                 .flatten()
                 .map(|p| p.len())
                 .unwrap_or(0),
-            config.get_image_url().ok().flatten().as_deref().unwrap_or(""),
+            config
+                .get_image_url()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
             if has_hint { "present" } else { "none" },
         );
     } else {
@@ -243,10 +183,7 @@ async fn main(spawner: Spawner) -> ! {
     esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
 
     // Status LED is on a different GPIO per device.
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
     let led_pin = peripherals.GPIO6;
-    #[cfg(feature = "e1004")]
-    let led_pin = peripherals.GPIO48;
     spawner.spawn(blink_task(Output::new(led_pin, Level::Low, OutputConfig::default())).unwrap());
 
     // One task that drives both per-wake sensor reads (battery ADC +
@@ -267,15 +204,13 @@ async fn main(spawner: Spawner) -> ! {
     // possible drawing through VBUS. This must happen after I²C0 is up
     // (the chip lives on this bus) but before any code that depends on
     // the BAT-only power path being established.
-    #[cfg(all(feature = "e1004", feature = "disable_charger"))]
-    let i2c0 = epd_photoframe::sy6974b::enter_measurement_mode(i2c0).await;
-
     spawner.spawn(
         epd_photoframe::normal_mode::sensor_task(
             Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
             peripherals.ADC1,
             peripherals.GPIO1,
             i2c0,
+            false,
         )
         .unwrap(),
     );
@@ -290,20 +225,11 @@ async fn main(spawner: Spawner) -> ! {
     )
     .unwrap();
 
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
     let mut epd_spi_bus = epd_spi_bus
         .with_sck(peripherals.GPIO7)
         .with_mosi(peripherals.GPIO9)
         .into_async();
 
-    #[cfg(feature = "e1004")]
-    let mut epd_spi_bus = epd_spi_bus
-        .with_sck(peripherals.GPIO7)
-        .with_miso(peripherals.GPIO8)
-        .with_mosi(peripherals.GPIO9)
-        .into_async();
-
-    #[cfg(feature = "e1001")]
     let epd = Gdey075t7::new(
         &mut epd_spi_bus,
         Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
@@ -312,33 +238,6 @@ async fn main(spawner: Spawner) -> ! {
             InputConfig::default().with_pull(Pull::Up),
         ),
         Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
-        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
-    );
-
-    #[cfg(feature = "e1002")]
-    let epd = Gdep073e01::new(
-        &mut epd_spi_bus,
-        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
-        Input::new(
-            peripherals.GPIO13,
-            InputConfig::default().with_pull(Pull::Up),
-        ),
-        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
-        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
-    );
-
-    #[cfg(feature = "e1004")]
-    let epd = T133A01::new(
-        &mut epd_spi_bus,
-        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
-        Output::new(peripherals.GPIO2, Level::Low, OutputConfig::default()),
-        Input::new(
-            peripherals.GPIO13,
-            InputConfig::default().with_pull(Pull::Up),
-        ),
-        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
-        Output::new(peripherals.GPIO38, Level::Low, OutputConfig::default()),
-        // GPIO12: TFT_EN board rail (E1004 only); high while the panel is powered.
         Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
     );
 
@@ -354,6 +253,8 @@ async fn main(spawner: Spawner) -> ! {
         rtc,
         wake_action,
         wifi: peripherals.WIFI,
+        refresh_button_label: "Refresh button (green)",
+        has_sy6974b: false,
         gpio_btn_refresh: gpio_btn_refresh.degrade(),
         gpio_btn_previous: gpio_btn_previous.degrade(),
         gpio_btn_next: gpio_btn_next.degrade(),
@@ -374,103 +275,5 @@ async fn main(spawner: Spawner) -> ! {
     // without a power-cycle. The `else` branch holds the rest of
     // `main()` so the divergence is structural — once we go into
     // `panic_mode::run` we never come back.
-    if let Some(panic_msg) = panic_mode::take_pending_message() {
-        panic_mode::run(hw, panic_msg.as_str()).await
-    } else {
-        run_normal_boot(hw, config).await
-    }
-}
-
-/// The non-panic boot path: flip the panic-reboot guard on, kick off
-/// the white pre-flash, run the config-mode hold race, and dispatch
-/// to either `normal_mode::run` (we have credentials and the user isn't
-/// holding both Previous + Next) or `config_mode::run`. Factored out
-/// of `main()` so the panic-render fast path's divergence reads as a
-/// clean two-arm `if let … else …` at the call site rather than
-/// "one arm calls a `-> !` function and the rest of the function
-/// implicitly only runs on the other arm".
-async fn run_normal_boot(
-    mut hw: HardwareCtx,
-    config: Config<'static>,
-) -> ! {
-    // Past the panic-render decision: any panic from here on is
-    // happening in a "normal" cycle, so the handler is allowed to
-    // stash + soft-reset (release builds) instead of halting. See
-    // `panic_mode::REBOOT_ALLOWED` for the why.
-    panic_mode::allow_reboot();
-
-    // --- White pre-flash (non-blocking) for immediate user feedback ---
-    //
-    // Kicked off before we decide which flow to run so the user sees the
-    // panel start updating as soon as the device wakes, even while the
-    // config-mode race is still counting down. Whichever flow wins will
-    // reset the panel to draw its own content on top; the ~20 s refresh
-    // just continues in the background until then.
-    if hw.wake_action.show_white_flash() {
-        println!("White pre-flash");
-        // Bring the panel's enable rail up before any panel I/O.
-        // `enable()` is idempotent (sets EN high), so a later flow
-        // (`normal_mode::run`, `config_mode::run`) re-asserting it is fine.
-        hw.epd.enable().await.unwrap();
-        println!("Reset");
-        hw.epd.reset().await.unwrap();
-        println!("Wait until idle");
-        hw.epd.wait_until_idle().await.unwrap();
-        println!("Init");
-        // Ask the panel which init mode covers an all-white palette;
-        // on E1001 that's `Bw`, single-mode panels return `()`.
-        let init_mode = EpdPanel::init_mode_for_palette([EpdColor::WHITE]);
-        hw.epd.init(&mut hw.spi_bus, init_mode).await.unwrap();
-        println!("Power on");
-        hw.epd.power_on(&mut hw.spi_bus).await.unwrap();
-        println!("Update frame (white)");
-        hw.epd
-            .update_frame(
-                &mut hw.spi_bus,
-                (0..(EpdPanel::WIDTH * EpdPanel::HEIGHT)).map(|_| EpdColor::WHITE),
-            )
-            .await
-            .unwrap();
-        println!("Trigger refresh (no wait)");
-        hw.epd.display_frame_no_wait(&mut hw.spi_bus).await.unwrap();
-    }
-
-    // If NVS didn't produce a full set of credentials we go straight to
-    // config mode without the button race. Otherwise: race a 10-second
-    // timer against either Previous or Next being released — if both were
-    // held at boot and stay held for the whole window, the timer wins and
-    // we enter configuration mode. If either (or both) was never pressed,
-    // `wait_for_high` resolves immediately because the pin is already high,
-    // so normally this block completes in microseconds.
-    let entering_config_mode = !config.is_configured().unwrap_or(false) || {
-        let mut prev_input = Input::new(
-            hw.gpio_btn_previous.reborrow(),
-            InputConfig::default().with_pull(Pull::Up),
-        );
-        let mut next_input = Input::new(
-            hw.gpio_btn_next.reborrow(),
-            InputConfig::default().with_pull(Pull::Up),
-        );
-        matches!(
-            embassy_futures::select::select3(
-                prev_input.wait_for_high(),
-                next_input.wait_for_high(),
-                Timer::at(Instant::MIN + Duration::from_secs(10)),
-            )
-            .await,
-            embassy_futures::select::Either3::Third(_)
-        )
-    };
-
-    if !entering_config_mode {
-        epd_photoframe::normal_mode::run(hw, config).await
-    } else {
-        // Entering config mode is a deliberate reset of the device's
-        // "what's displayed" state — whatever URL was committed last
-        // cycle (and any pending redirect) is no longer relevant once
-        // the user has reconfigured.
-        epd_photoframe::normal_mode::CURRENT_URL.clear();
-        epd_photoframe::normal_mode::REDIRECT_URL.clear();
-        config_mode::run(hw, config).await
-    }
+    epd_photoframe::app::run(hw, config).await
 }

--- a/src/bin/e1001.rs
+++ b/src/bin/e1001.rs
@@ -70,33 +70,13 @@ async fn main(spawner: Spawner) -> ! {
     // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
     // the rest of main() is device-agnostic. E1001 inherits the E1002
     // mapping (same hardware aside from the panel).
-    let (mut gpio_btn_refresh, mut gpio_btn_previous, mut gpio_btn_next) =
+    let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next) =
         (peripherals.GPIO3, peripherals.GPIO5, peripherals.GPIO4);
-
-    // Read all three buttons ASAP so we capture the press even if the user
-    // releases quickly after powering the device out of deep sleep.
-    let refresh_held = Input::new(
-        gpio_btn_refresh.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
-    let previous_held = Input::new(
-        gpio_btn_previous.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
-    let next_held = Input::new(
-        gpio_btn_next.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
 
     // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
     // and clear it immediately so stale bits don't carry into the next cycle.
     // The latch is authoritative because it captures the pin state at the
-    // exact moment of wake — even a sub-millisecond tap is recorded, whereas
-    // the current-level read above misses anything released during the
-    // ~300 ms bootloader window.
+    // exact moment of wake — even a sub-millisecond tap is recorded.
     let button_bits = (1u32 << gpio_btn_refresh.number())
         | (1u32 << gpio_btn_previous.number())
         | (1u32 << gpio_btn_next.number());
@@ -119,7 +99,6 @@ async fn main(spawner: Spawner) -> ! {
     println!(
         "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
          latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
-         held[refresh={refresh_held} previous={previous_held} next={next_held}] \
          uptime={time_since_boot:?}"
     );
     println!(

--- a/src/bin/e1002.rs
+++ b/src/bin/e1002.rs
@@ -1,0 +1,279 @@
+#![no_std]
+#![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
+
+use embassy_executor::Spawner;
+use embassy_time::{Duration, Timer};
+use esp_hal::clock::CpuClock;
+use esp_hal::timer::timg::TimerGroup;
+
+use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
+use esp_hal::gpio::{Level, Output, OutputConfig};
+use esp_println::println;
+
+use esp_hal::spi::Mode as SpiMode;
+use esp_hal::spi::master::Config as SpiConfig;
+use esp_hal::spi::master::Spi;
+
+extern crate alloc;
+
+use epd_photoframe::config::Config;
+use epd_photoframe::hardware::HardwareCtx;
+use epd_photoframe::panel::gdep073e01::Gdep073e01;
+
+// This creates a default app-descriptor required by the esp-idf bootloader.
+// For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// Read the RTC-IO interrupt status register (the wake latch) masked to the
+/// caller's bits of interest, clear those same bits via the register's
+/// write-1-to-clear sibling, and return the pre-clear masked value. Other
+/// bits in the register are neither read back nor touched.
+///
+/// Wraps the single `unsafe` the PAC mandates for this register: svd2rust
+/// marks `RTC_GPIO_STATUS_W1TC` with `Safety = Unsafe` because it can't
+/// statically verify field-value semantics, but writing any `u32` mask to
+/// a write-1-to-clear status register only flips hardware status bits in
+/// the RTC domain and cannot violate memory safety.
+fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
+    let rtc_io = esp_hal::peripherals::RTC_IO::regs();
+    let value = rtc_io.rtc_gpio_status().read().int().bits() & mask;
+    unsafe {
+        rtc_io
+            .rtc_gpio_status_w1tc()
+            .write(|w| w.rtc_gpio_status_int_w1tc().bits(mask));
+    }
+    value
+}
+
+#[embassy_executor::task]
+async fn blink_task(mut led: Output<'static>) {
+    loop {
+        led.toggle();
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) -> ! {
+    let reset_reason = esp_hal::rtc_cntl::reset_reason(esp_hal::system::Cpu::ProCpu);
+    let wake_reason = esp_hal::rtc_cntl::wakeup_cause();
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    let peripherals = esp_hal::init(config);
+
+    // Bind semantic button names to the device-specific GPIOs. This is the
+    // only place where the silkscreen-to-GPIO mapping appears; everything
+    // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
+    // the rest of main() is device-agnostic. E1001 inherits the E1002
+    // mapping (same hardware aside from the panel).
+    let (mut gpio_btn_refresh, mut gpio_btn_previous, mut gpio_btn_next) =
+        (peripherals.GPIO3, peripherals.GPIO5, peripherals.GPIO4);
+
+    // Read all three buttons ASAP so we capture the press even if the user
+    // releases quickly after powering the device out of deep sleep.
+    let refresh_held = Input::new(
+        gpio_btn_refresh.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    )
+    .is_low();
+    let previous_held = Input::new(
+        gpio_btn_previous.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    )
+    .is_low();
+    let next_held = Input::new(
+        gpio_btn_next.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    )
+    .is_low();
+
+    // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
+    // and clear it immediately so stale bits don't carry into the next cycle.
+    // The latch is authoritative because it captures the pin state at the
+    // exact moment of wake — even a sub-millisecond tap is recorded, whereas
+    // the current-level read above misses anything released during the
+    // ~300 ms bootloader window.
+    let button_bits = (1u32 << gpio_btn_refresh.number())
+        | (1u32 << gpio_btn_previous.number())
+        | (1u32 << gpio_btn_next.number());
+    let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
+
+    let refresh_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_refresh.number())) != 0;
+    let previous_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_previous.number())) != 0;
+    let next_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_next.number())) != 0;
+
+    let wake_action = epd_photoframe::app::determine_wake_action(
+        reset_reason,
+        wake_reason,
+        refresh_latched,
+        previous_latched,
+        next_latched,
+    );
+
+    let rtc = esp_hal::rtc_cntl::Rtc::new(peripherals.LPWR);
+    let time_since_boot = rtc.time_since_power_up();
+    println!(
+        "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
+         latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
+         held[refresh={refresh_held} previous={previous_held} next={next_held}] \
+         uptime={time_since_boot:?}"
+    );
+    println!(
+        "RTC CURRENT_URL: {:?}",
+        epd_photoframe::normal_mode::CURRENT_URL.get().as_deref()
+    );
+    println!(
+        "RTC REDIRECT_URL: {:?}",
+        epd_photoframe::normal_mode::REDIRECT_URL.get().as_deref()
+    );
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
+    esp_alloc::psram_allocator!(
+        peripherals.PSRAM,
+        esp_hal::psram,
+        esp_hal::psram::PsramConfig {
+            mode: esp_hal::psram::PsramMode::OctalSpi,
+            ..Default::default()
+        }
+    );
+
+    // Load runtime configuration from NVS. A fresh / blank partition is
+    // not an error (esp-nvs treats all-0xFF as "no entries yet"), so the
+    // only ways `Config::new` fails are programming bugs (wrong partition
+    // offset/size) or actual flash hardware trouble — panicking there is
+    // the right call. A missing *key* is different: that's how we detect
+    // "needs configuring" and short-circuit into config mode below.
+    let config =
+        Config::new(peripherals.FLASH).expect("NVS init failed — check partition table and flash");
+    if config.is_configured().unwrap_or(false) {
+        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
+        println!(
+            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
+            config
+                .get_wifi_ssid()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
+            config
+                .get_wifi_password()
+                .ok()
+                .flatten()
+                .map(|p| p.len())
+                .unwrap_or(0),
+            config
+                .get_image_url()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
+            if has_hint { "present" } else { "none" },
+        );
+    } else {
+        println!("NVS config incomplete; forcing config mode");
+    }
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    let sw_ints =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+    // Status LED is on a different GPIO per device.
+    let led_pin = peripherals.GPIO6;
+    spawner.spawn(blink_task(Output::new(led_pin, Level::Low, OutputConfig::default())).unwrap());
+
+    // One task that drives both per-wake sensor reads (battery ADC +
+    // SHT40 over I²C0) concurrently via `join`. By the time the URL
+    // is being built in `normal_mode::run`, both signals have been
+    // populated — the 10 ms ADC settle + the 10 ms SHT40 conversion
+    // happen alongside the ~1.3 s WiFi association, so the `wait()`s
+    // are essentially free.
+    let i2c0 =
+        esp_hal::i2c::master::I2c::new(peripherals.I2C0, esp_hal::i2c::master::Config::default())
+            .unwrap()
+            .with_sda(peripherals.GPIO19)
+            .with_scl(peripherals.GPIO20)
+            .into_async();
+
+    // PPK2 measurement mode: park the SY6974B charger in HIZ before
+    // anything else runs so the system rail spends as little time as
+    // possible drawing through VBUS. This must happen after I²C0 is up
+    // (the chip lives on this bus) but before any code that depends on
+    // the BAT-only power path being established.
+    spawner.spawn(
+        epd_photoframe::normal_mode::sensor_task(
+            Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
+            peripherals.ADC1,
+            peripherals.GPIO1,
+            i2c0,
+            false,
+        )
+        .unwrap(),
+    );
+
+    // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
+    let epd_spi_bus = Spi::new(
+        peripherals.SPI2,
+        SpiConfig::default()
+            .with_write_bit_order(esp_hal::spi::BitOrder::MsbFirst)
+            .with_frequency(esp_hal::time::Rate::from_mhz(20))
+            .with_mode(SpiMode::_0),
+    )
+    .unwrap();
+
+    let mut epd_spi_bus = epd_spi_bus
+        .with_sck(peripherals.GPIO7)
+        .with_mosi(peripherals.GPIO9)
+        .into_async();
+
+    let epd = Gdep073e01::new(
+        &mut epd_spi_bus,
+        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
+        Input::new(
+            peripherals.GPIO13,
+            InputConfig::default().with_pull(Pull::Up),
+        ),
+        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
+        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
+    );
+
+    // Unified hardware context handed off to whichever top-level flow
+    // wins (`panic_mode::run`, `run_normal_boot`, then `normal_mode::run`
+    // or `config_mode::run`). The panel's board-level enable rail
+    // (E1004's TFT_EN; no-op on E1002 / E1001) stays *off* here —
+    // each flow asserts it (idempotently) before its own first panel
+    // I/O, so the rail is only powered when the panel is about to be
+    // touched.
+    let hw = HardwareCtx {
+        spawner,
+        rtc,
+        wake_action,
+        wifi: peripherals.WIFI,
+        refresh_button_label: "Refresh button (green)",
+        has_sy6974b: false,
+        gpio_btn_refresh: gpio_btn_refresh.degrade(),
+        gpio_btn_previous: gpio_btn_previous.degrade(),
+        gpio_btn_next: gpio_btn_next.degrade(),
+        spi_bus: epd_spi_bus,
+        epd,
+        buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
+    };
+
+    // --- Panic-render fast path -----------------------------------------
+    //
+    // If the previous boot ended in a panic, the release-build panic
+    // handler stashed the formatted message in `panic_mode::PANIC_MSG`
+    // and soft-reset. `take_pending_message` clears the slot, so a
+    // re-panic during render falls back to a normal cycle on the next
+    // boot rather than looping. Skips white pre-flash, WiFi, sensors,
+    // and the config-mode race: just renders the message and deep-
+    // sleeps, wakeable by timer or button so the user can retry
+    // without a power-cycle. The `else` branch holds the rest of
+    // `main()` so the divergence is structural — once we go into
+    // `panic_mode::run` we never come back.
+    epd_photoframe::app::run(hw, config).await
+}

--- a/src/bin/e1002.rs
+++ b/src/bin/e1002.rs
@@ -70,33 +70,13 @@ async fn main(spawner: Spawner) -> ! {
     // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
     // the rest of main() is device-agnostic. E1001 inherits the E1002
     // mapping (same hardware aside from the panel).
-    let (mut gpio_btn_refresh, mut gpio_btn_previous, mut gpio_btn_next) =
+    let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next) =
         (peripherals.GPIO3, peripherals.GPIO5, peripherals.GPIO4);
-
-    // Read all three buttons ASAP so we capture the press even if the user
-    // releases quickly after powering the device out of deep sleep.
-    let refresh_held = Input::new(
-        gpio_btn_refresh.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
-    let previous_held = Input::new(
-        gpio_btn_previous.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
-    let next_held = Input::new(
-        gpio_btn_next.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
 
     // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
     // and clear it immediately so stale bits don't carry into the next cycle.
     // The latch is authoritative because it captures the pin state at the
-    // exact moment of wake — even a sub-millisecond tap is recorded, whereas
-    // the current-level read above misses anything released during the
-    // ~300 ms bootloader window.
+    // exact moment of wake — even a sub-millisecond tap is recorded.
     let button_bits = (1u32 << gpio_btn_refresh.number())
         | (1u32 << gpio_btn_previous.number())
         | (1u32 << gpio_btn_next.number());
@@ -119,7 +99,6 @@ async fn main(spawner: Spawner) -> ! {
     println!(
         "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
          latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
-         held[refresh={refresh_held} previous={previous_held} next={next_held}] \
          uptime={time_since_boot:?}"
     );
     println!(

--- a/src/bin/e1002.rs
+++ b/src/bin/e1002.rs
@@ -7,194 +7,29 @@
 )]
 
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use esp_hal::clock::CpuClock;
-use esp_hal::timer::timg::TimerGroup;
-
-use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
-use esp_hal::gpio::{Level, Output, OutputConfig};
-use esp_println::println;
-
+use esp_hal::gpio::{Input, InputConfig, Level, Output, OutputConfig, Pin, Pull};
 use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
 
 extern crate alloc;
 
-use epd_photoframe::config::Config;
-use epd_photoframe::hardware::HardwareCtx;
+use epd_photoframe::hardware::AppHardware;
 use epd_photoframe::panel::gdep073e01::Gdep073e01;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
 // For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
 esp_bootloader_esp_idf::esp_app_desc!();
 
-/// Read the RTC-IO interrupt status register (the wake latch) masked to the
-/// caller's bits of interest, clear those same bits via the register's
-/// write-1-to-clear sibling, and return the pre-clear masked value. Other
-/// bits in the register are neither read back nor touched.
-///
-/// Wraps the single `unsafe` the PAC mandates for this register: svd2rust
-/// marks `RTC_GPIO_STATUS_W1TC` with `Safety = Unsafe` because it can't
-/// statically verify field-value semantics, but writing any `u32` mask to
-/// a write-1-to-clear status register only flips hardware status bits in
-/// the RTC domain and cannot violate memory safety.
-fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
-    let rtc_io = esp_hal::peripherals::RTC_IO::regs();
-    let value = rtc_io.rtc_gpio_status().read().int().bits() & mask;
-    unsafe {
-        rtc_io
-            .rtc_gpio_status_w1tc()
-            .write(|w| w.rtc_gpio_status_int_w1tc().bits(mask));
-    }
-    value
-}
-
-#[embassy_executor::task]
-async fn blink_task(mut led: Output<'static>) {
-    loop {
-        led.toggle();
-        Timer::after(Duration::from_millis(500)).await;
-    }
-}
-
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let reset_reason = esp_hal::rtc_cntl::reset_reason(esp_hal::system::Cpu::ProCpu);
     let wake_reason = esp_hal::rtc_cntl::wakeup_cause();
-    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
-    let peripherals = esp_hal::init(config);
+    let peripherals = epd_photoframe::app::init();
 
-    // Bind semantic button names to the device-specific GPIOs. This is the
-    // only place where the silkscreen-to-GPIO mapping appears; everything
-    // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
-    // the rest of main() is device-agnostic. E1001 inherits the E1002
-    // mapping (same hardware aside from the panel).
     let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next) =
         (peripherals.GPIO3, peripherals.GPIO5, peripherals.GPIO4);
 
-    // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
-    // and clear it immediately so stale bits don't carry into the next cycle.
-    // The latch is authoritative because it captures the pin state at the
-    // exact moment of wake — even a sub-millisecond tap is recorded.
-    let button_bits = (1u32 << gpio_btn_refresh.number())
-        | (1u32 << gpio_btn_previous.number())
-        | (1u32 << gpio_btn_next.number());
-    let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
-
-    let refresh_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_refresh.number())) != 0;
-    let previous_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_previous.number())) != 0;
-    let next_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_next.number())) != 0;
-
-    let wake_action = epd_photoframe::app::determine_wake_action(
-        reset_reason,
-        wake_reason,
-        refresh_latched,
-        previous_latched,
-        next_latched,
-    );
-
-    let rtc = esp_hal::rtc_cntl::Rtc::new(peripherals.LPWR);
-    let time_since_boot = rtc.time_since_power_up();
-    println!(
-        "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
-         latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
-         uptime={time_since_boot:?}"
-    );
-    println!(
-        "RTC CURRENT_URL: {:?}",
-        epd_photoframe::normal_mode::CURRENT_URL.get().as_deref()
-    );
-    println!(
-        "RTC REDIRECT_URL: {:?}",
-        epd_photoframe::normal_mode::REDIRECT_URL.get().as_deref()
-    );
-
-    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
-    esp_alloc::psram_allocator!(
-        peripherals.PSRAM,
-        esp_hal::psram,
-        esp_hal::psram::PsramConfig {
-            mode: esp_hal::psram::PsramMode::OctalSpi,
-            ..Default::default()
-        }
-    );
-
-    // Load runtime configuration from NVS. A fresh / blank partition is
-    // not an error (esp-nvs treats all-0xFF as "no entries yet"), so the
-    // only ways `Config::new` fails are programming bugs (wrong partition
-    // offset/size) or actual flash hardware trouble — panicking there is
-    // the right call. A missing *key* is different: that's how we detect
-    // "needs configuring" and short-circuit into config mode below.
-    let config =
-        Config::new(peripherals.FLASH).expect("NVS init failed — check partition table and flash");
-    if config.is_configured().unwrap_or(false) {
-        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
-        println!(
-            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
-            config
-                .get_wifi_ssid()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            config
-                .get_wifi_password()
-                .ok()
-                .flatten()
-                .map(|p| p.len())
-                .unwrap_or(0),
-            config
-                .get_image_url()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            if has_hint { "present" } else { "none" },
-        );
-    } else {
-        println!("NVS config incomplete; forcing config mode");
-    }
-
-    let timg0 = TimerGroup::new(peripherals.TIMG0);
-    let sw_ints =
-        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
-
-    // Status LED is on a different GPIO per device.
-    let led_pin = peripherals.GPIO6;
-    spawner.spawn(blink_task(Output::new(led_pin, Level::Low, OutputConfig::default())).unwrap());
-
-    // One task that drives both per-wake sensor reads (battery ADC +
-    // SHT40 over I²C0) concurrently via `join`. By the time the URL
-    // is being built in `normal_mode::run`, both signals have been
-    // populated — the 10 ms ADC settle + the 10 ms SHT40 conversion
-    // happen alongside the ~1.3 s WiFi association, so the `wait()`s
-    // are essentially free.
-    let i2c0 =
-        esp_hal::i2c::master::I2c::new(peripherals.I2C0, esp_hal::i2c::master::Config::default())
-            .unwrap()
-            .with_sda(peripherals.GPIO19)
-            .with_scl(peripherals.GPIO20)
-            .into_async();
-
-    // PPK2 measurement mode: park the SY6974B charger in HIZ before
-    // anything else runs so the system rail spends as little time as
-    // possible drawing through VBUS. This must happen after I²C0 is up
-    // (the chip lives on this bus) but before any code that depends on
-    // the BAT-only power path being established.
-    spawner.spawn(
-        epd_photoframe::normal_mode::sensor_task(
-            Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
-            peripherals.ADC1,
-            peripherals.GPIO1,
-            i2c0,
-            false,
-        )
-        .unwrap(),
-    );
-
-    // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
     let epd_spi_bus = Spi::new(
         peripherals.SPI2,
         SpiConfig::default()
@@ -220,39 +55,31 @@ async fn main(spawner: Spawner) -> ! {
         Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
     );
 
-    // Unified hardware context handed off to whichever top-level flow
-    // wins (`panic_mode::run`, `run_normal_boot`, then `normal_mode::run`
-    // or `config_mode::run`). The panel's board-level enable rail
-    // (E1004's TFT_EN; no-op on E1002 / E1001) stays *off* here —
-    // each flow asserts it (idempotently) before its own first panel
-    // I/O, so the rail is only powered when the panel is about to be
-    // touched.
-    let hw = HardwareCtx {
+    epd_photoframe::app::run(AppHardware {
         spawner,
-        rtc,
-        wake_action,
+        reset_reason,
+        wake_reason,
         wifi: peripherals.WIFI,
+        flash: peripherals.FLASH,
+        psram: peripherals.PSRAM,
+        lpwr: peripherals.LPWR,
+        timg0: peripherals.TIMG0,
+        sw_interrupt: peripherals.SW_INTERRUPT,
+        status_led: peripherals.GPIO6.degrade(),
         refresh_button_label: "Refresh button (green)",
         has_sy6974b: false,
+        i2c0: peripherals.I2C0,
+        gpio_i2c_sda: peripherals.GPIO19,
+        gpio_i2c_scl: peripherals.GPIO20,
+        adc1: peripherals.ADC1,
+        gpio_battery_enable: peripherals.GPIO21,
+        gpio_battery_sense: peripherals.GPIO1,
         gpio_btn_refresh: gpio_btn_refresh.degrade(),
         gpio_btn_previous: gpio_btn_previous.degrade(),
         gpio_btn_next: gpio_btn_next.degrade(),
         spi_bus: epd_spi_bus,
         epd,
         buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
-    };
-
-    // --- Panic-render fast path -----------------------------------------
-    //
-    // If the previous boot ended in a panic, the release-build panic
-    // handler stashed the formatted message in `panic_mode::PANIC_MSG`
-    // and soft-reset. `take_pending_message` clears the slot, so a
-    // re-panic during render falls back to a normal cycle on the next
-    // boot rather than looping. Skips white pre-flash, WiFi, sensors,
-    // and the config-mode race: just renders the message and deep-
-    // sleeps, wakeable by timer or button so the user can retry
-    // without a power-cycle. The `else` branch holds the rest of
-    // `main()` so the divergence is structural — once we go into
-    // `panic_mode::run` we never come back.
-    epd_photoframe::app::run(hw, config).await
+    })
+    .await
 }

--- a/src/bin/e1002.rs
+++ b/src/bin/e1002.rs
@@ -14,7 +14,7 @@ use esp_hal::spi::master::Spi;
 
 extern crate alloc;
 
-use epd_photoframe::hardware::AppHardware;
+use epd_photoframe::app::App;
 use epd_photoframe::panel::gdep073e01::Gdep073e01;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
@@ -55,7 +55,7 @@ async fn main(spawner: Spawner) -> ! {
         Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
     );
 
-    epd_photoframe::app::run(AppHardware {
+    App {
         spawner,
         reset_reason,
         wake_reason,
@@ -80,6 +80,7 @@ async fn main(spawner: Spawner) -> ! {
         spi_bus: epd_spi_bus,
         epd,
         buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
-    })
+    }
+    .run()
     .await
 }

--- a/src/bin/e1004.rs
+++ b/src/bin/e1004.rs
@@ -70,33 +70,13 @@ async fn main(spawner: Spawner) -> ! {
     // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
     // the rest of main() is device-agnostic. E1001 inherits the E1002
     // mapping (same hardware aside from the panel).
-    let (mut gpio_btn_refresh, mut gpio_btn_previous, mut gpio_btn_next) =
+    let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next) =
         (peripherals.GPIO5, peripherals.GPIO4, peripherals.GPIO3);
-
-    // Read all three buttons ASAP so we capture the press even if the user
-    // releases quickly after powering the device out of deep sleep.
-    let refresh_held = Input::new(
-        gpio_btn_refresh.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
-    let previous_held = Input::new(
-        gpio_btn_previous.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
-    let next_held = Input::new(
-        gpio_btn_next.reborrow(),
-        InputConfig::default().with_pull(Pull::Up),
-    )
-    .is_low();
 
     // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
     // and clear it immediately so stale bits don't carry into the next cycle.
     // The latch is authoritative because it captures the pin state at the
-    // exact moment of wake — even a sub-millisecond tap is recorded, whereas
-    // the current-level read above misses anything released during the
-    // ~300 ms bootloader window.
+    // exact moment of wake — even a sub-millisecond tap is recorded.
     let button_bits = (1u32 << gpio_btn_refresh.number())
         | (1u32 << gpio_btn_previous.number())
         | (1u32 << gpio_btn_next.number());
@@ -119,7 +99,6 @@ async fn main(spawner: Spawner) -> ! {
     println!(
         "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
          latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
-         held[refresh={refresh_held} previous={previous_held} next={next_held}] \
          uptime={time_since_boot:?}"
     );
     println!(

--- a/src/bin/e1004.rs
+++ b/src/bin/e1004.rs
@@ -7,197 +7,29 @@
 )]
 
 use embassy_executor::Spawner;
-use embassy_time::{Duration, Timer};
-use esp_hal::clock::CpuClock;
-use esp_hal::timer::timg::TimerGroup;
-
-use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
-use esp_hal::gpio::{Level, Output, OutputConfig};
-use esp_println::println;
-
+use esp_hal::gpio::{Input, InputConfig, Level, Output, OutputConfig, Pin, Pull};
 use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
 
 extern crate alloc;
 
-use epd_photoframe::config::Config;
-use epd_photoframe::hardware::HardwareCtx;
+use epd_photoframe::hardware::AppHardware;
 use epd_photoframe::panel::t133a01::T133A01;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
 // For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
 esp_bootloader_esp_idf::esp_app_desc!();
 
-/// Read the RTC-IO interrupt status register (the wake latch) masked to the
-/// caller's bits of interest, clear those same bits via the register's
-/// write-1-to-clear sibling, and return the pre-clear masked value. Other
-/// bits in the register are neither read back nor touched.
-///
-/// Wraps the single `unsafe` the PAC mandates for this register: svd2rust
-/// marks `RTC_GPIO_STATUS_W1TC` with `Safety = Unsafe` because it can't
-/// statically verify field-value semantics, but writing any `u32` mask to
-/// a write-1-to-clear status register only flips hardware status bits in
-/// the RTC domain and cannot violate memory safety.
-fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
-    let rtc_io = esp_hal::peripherals::RTC_IO::regs();
-    let value = rtc_io.rtc_gpio_status().read().int().bits() & mask;
-    unsafe {
-        rtc_io
-            .rtc_gpio_status_w1tc()
-            .write(|w| w.rtc_gpio_status_int_w1tc().bits(mask));
-    }
-    value
-}
-
-#[embassy_executor::task]
-async fn blink_task(mut led: Output<'static>) {
-    loop {
-        led.toggle();
-        Timer::after(Duration::from_millis(500)).await;
-    }
-}
-
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
     let reset_reason = esp_hal::rtc_cntl::reset_reason(esp_hal::system::Cpu::ProCpu);
     let wake_reason = esp_hal::rtc_cntl::wakeup_cause();
-    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
-    let peripherals = esp_hal::init(config);
+    let peripherals = epd_photoframe::app::init();
 
-    // Bind semantic button names to the device-specific GPIOs. This is the
-    // only place where the silkscreen-to-GPIO mapping appears; everything
-    // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
-    // the rest of main() is device-agnostic. E1001 inherits the E1002
-    // mapping (same hardware aside from the panel).
     let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next) =
         (peripherals.GPIO5, peripherals.GPIO4, peripherals.GPIO3);
 
-    // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
-    // and clear it immediately so stale bits don't carry into the next cycle.
-    // The latch is authoritative because it captures the pin state at the
-    // exact moment of wake — even a sub-millisecond tap is recorded.
-    let button_bits = (1u32 << gpio_btn_refresh.number())
-        | (1u32 << gpio_btn_previous.number())
-        | (1u32 << gpio_btn_next.number());
-    let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
-
-    let refresh_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_refresh.number())) != 0;
-    let previous_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_previous.number())) != 0;
-    let next_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_next.number())) != 0;
-
-    let wake_action = epd_photoframe::app::determine_wake_action(
-        reset_reason,
-        wake_reason,
-        refresh_latched,
-        previous_latched,
-        next_latched,
-    );
-
-    let rtc = esp_hal::rtc_cntl::Rtc::new(peripherals.LPWR);
-    let time_since_boot = rtc.time_since_power_up();
-    println!(
-        "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
-         latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
-         uptime={time_since_boot:?}"
-    );
-    println!(
-        "RTC CURRENT_URL: {:?}",
-        epd_photoframe::normal_mode::CURRENT_URL.get().as_deref()
-    );
-    println!(
-        "RTC REDIRECT_URL: {:?}",
-        epd_photoframe::normal_mode::REDIRECT_URL.get().as_deref()
-    );
-
-    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
-    esp_alloc::psram_allocator!(
-        peripherals.PSRAM,
-        esp_hal::psram,
-        esp_hal::psram::PsramConfig {
-            mode: esp_hal::psram::PsramMode::OctalSpi,
-            ..Default::default()
-        }
-    );
-
-    // Load runtime configuration from NVS. A fresh / blank partition is
-    // not an error (esp-nvs treats all-0xFF as "no entries yet"), so the
-    // only ways `Config::new` fails are programming bugs (wrong partition
-    // offset/size) or actual flash hardware trouble — panicking there is
-    // the right call. A missing *key* is different: that's how we detect
-    // "needs configuring" and short-circuit into config mode below.
-    let config =
-        Config::new(peripherals.FLASH).expect("NVS init failed — check partition table and flash");
-    if config.is_configured().unwrap_or(false) {
-        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
-        println!(
-            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
-            config
-                .get_wifi_ssid()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            config
-                .get_wifi_password()
-                .ok()
-                .flatten()
-                .map(|p| p.len())
-                .unwrap_or(0),
-            config
-                .get_image_url()
-                .ok()
-                .flatten()
-                .as_deref()
-                .unwrap_or(""),
-            if has_hint { "present" } else { "none" },
-        );
-    } else {
-        println!("NVS config incomplete; forcing config mode");
-    }
-
-    let timg0 = TimerGroup::new(peripherals.TIMG0);
-    let sw_ints =
-        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
-
-    // Status LED is on a different GPIO per device.
-    let led_pin = peripherals.GPIO48;
-    spawner.spawn(blink_task(Output::new(led_pin, Level::Low, OutputConfig::default())).unwrap());
-
-    // One task that drives both per-wake sensor reads (battery ADC +
-    // SHT40 over I²C0) concurrently via `join`. By the time the URL
-    // is being built in `normal_mode::run`, both signals have been
-    // populated — the 10 ms ADC settle + the 10 ms SHT40 conversion
-    // happen alongside the ~1.3 s WiFi association, so the `wait()`s
-    // are essentially free.
-    let i2c0 =
-        esp_hal::i2c::master::I2c::new(peripherals.I2C0, esp_hal::i2c::master::Config::default())
-            .unwrap()
-            .with_sda(peripherals.GPIO19)
-            .with_scl(peripherals.GPIO20)
-            .into_async();
-
-    // PPK2 measurement mode: park the SY6974B charger in HIZ before
-    // anything else runs so the system rail spends as little time as
-    // possible drawing through VBUS. This must happen after I²C0 is up
-    // (the chip lives on this bus) but before any code that depends on
-    // the BAT-only power path being established.
-    #[cfg(feature = "disable_charger")]
-    let i2c0 = epd_photoframe::sy6974b::enter_measurement_mode(i2c0).await;
-
-    spawner.spawn(
-        epd_photoframe::normal_mode::sensor_task(
-            Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
-            peripherals.ADC1,
-            peripherals.GPIO1,
-            i2c0,
-            true,
-        )
-        .unwrap(),
-    );
-
-    // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
     let epd_spi_bus = Spi::new(
         peripherals.SPI2,
         SpiConfig::default()
@@ -227,39 +59,31 @@ async fn main(spawner: Spawner) -> ! {
         Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
     );
 
-    // Unified hardware context handed off to whichever top-level flow
-    // wins (`panic_mode::run`, `run_normal_boot`, then `normal_mode::run`
-    // or `config_mode::run`). The panel's board-level enable rail
-    // (E1004's TFT_EN; no-op on E1002 / E1001) stays *off* here —
-    // each flow asserts it (idempotently) before its own first panel
-    // I/O, so the rail is only powered when the panel is about to be
-    // touched.
-    let hw = HardwareCtx {
+    epd_photoframe::app::run(AppHardware {
         spawner,
-        rtc,
-        wake_action,
+        reset_reason,
+        wake_reason,
         wifi: peripherals.WIFI,
+        flash: peripherals.FLASH,
+        psram: peripherals.PSRAM,
+        lpwr: peripherals.LPWR,
+        timg0: peripherals.TIMG0,
+        sw_interrupt: peripherals.SW_INTERRUPT,
+        status_led: peripherals.GPIO48.degrade(),
         refresh_button_label: "Refresh button",
         has_sy6974b: true,
+        i2c0: peripherals.I2C0,
+        gpio_i2c_sda: peripherals.GPIO19,
+        gpio_i2c_scl: peripherals.GPIO20,
+        adc1: peripherals.ADC1,
+        gpio_battery_enable: peripherals.GPIO21,
+        gpio_battery_sense: peripherals.GPIO1,
         gpio_btn_refresh: gpio_btn_refresh.degrade(),
         gpio_btn_previous: gpio_btn_previous.degrade(),
         gpio_btn_next: gpio_btn_next.degrade(),
         spi_bus: epd_spi_bus,
         epd,
         buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
-    };
-
-    // --- Panic-render fast path -----------------------------------------
-    //
-    // If the previous boot ended in a panic, the release-build panic
-    // handler stashed the formatted message in `panic_mode::PANIC_MSG`
-    // and soft-reset. `take_pending_message` clears the slot, so a
-    // re-panic during render falls back to a normal cycle on the next
-    // boot rather than looping. Skips white pre-flash, WiFi, sensors,
-    // and the config-mode race: just renders the message and deep-
-    // sleeps, wakeable by timer or button so the user can retry
-    // without a power-cycle. The `else` branch holds the rest of
-    // `main()` so the divergence is structural — once we go into
-    // `panic_mode::run` we never come back.
-    epd_photoframe::app::run(hw, config).await
+    })
+    .await
 }

--- a/src/bin/e1004.rs
+++ b/src/bin/e1004.rs
@@ -14,7 +14,7 @@ use esp_hal::spi::master::Spi;
 
 extern crate alloc;
 
-use epd_photoframe::hardware::AppHardware;
+use epd_photoframe::app::App;
 use epd_photoframe::panel::t133a01::T133A01;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
@@ -59,7 +59,7 @@ async fn main(spawner: Spawner) -> ! {
         Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
     );
 
-    epd_photoframe::app::run(AppHardware {
+    App {
         spawner,
         reset_reason,
         wake_reason,
@@ -84,6 +84,7 @@ async fn main(spawner: Spawner) -> ! {
         spi_bus: epd_spi_bus,
         epd,
         buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
-    })
+    }
+    .run()
     .await
 }

--- a/src/bin/e1004.rs
+++ b/src/bin/e1004.rs
@@ -1,0 +1,286 @@
+#![no_std]
+#![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
+
+use embassy_executor::Spawner;
+use embassy_time::{Duration, Timer};
+use esp_hal::clock::CpuClock;
+use esp_hal::timer::timg::TimerGroup;
+
+use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
+use esp_hal::gpio::{Level, Output, OutputConfig};
+use esp_println::println;
+
+use esp_hal::spi::Mode as SpiMode;
+use esp_hal::spi::master::Config as SpiConfig;
+use esp_hal::spi::master::Spi;
+
+extern crate alloc;
+
+use epd_photoframe::config::Config;
+use epd_photoframe::hardware::HardwareCtx;
+use epd_photoframe::panel::t133a01::T133A01;
+
+// This creates a default app-descriptor required by the esp-idf bootloader.
+// For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
+esp_bootloader_esp_idf::esp_app_desc!();
+
+/// Read the RTC-IO interrupt status register (the wake latch) masked to the
+/// caller's bits of interest, clear those same bits via the register's
+/// write-1-to-clear sibling, and return the pre-clear masked value. Other
+/// bits in the register are neither read back nor touched.
+///
+/// Wraps the single `unsafe` the PAC mandates for this register: svd2rust
+/// marks `RTC_GPIO_STATUS_W1TC` with `Safety = Unsafe` because it can't
+/// statically verify field-value semantics, but writing any `u32` mask to
+/// a write-1-to-clear status register only flips hardware status bits in
+/// the RTC domain and cannot violate memory safety.
+fn read_and_clear_rtc_gpio_wake_status(mask: u32) -> u32 {
+    let rtc_io = esp_hal::peripherals::RTC_IO::regs();
+    let value = rtc_io.rtc_gpio_status().read().int().bits() & mask;
+    unsafe {
+        rtc_io
+            .rtc_gpio_status_w1tc()
+            .write(|w| w.rtc_gpio_status_int_w1tc().bits(mask));
+    }
+    value
+}
+
+#[embassy_executor::task]
+async fn blink_task(mut led: Output<'static>) {
+    loop {
+        led.toggle();
+        Timer::after(Duration::from_millis(500)).await;
+    }
+}
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) -> ! {
+    let reset_reason = esp_hal::rtc_cntl::reset_reason(esp_hal::system::Cpu::ProCpu);
+    let wake_reason = esp_hal::rtc_cntl::wakeup_cause();
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    let peripherals = esp_hal::init(config);
+
+    // Bind semantic button names to the device-specific GPIOs. This is the
+    // only place where the silkscreen-to-GPIO mapping appears; everything
+    // downstream uses the `gpio_btn_*` handles (and their `.number()`) so
+    // the rest of main() is device-agnostic. E1001 inherits the E1002
+    // mapping (same hardware aside from the panel).
+    let (mut gpio_btn_refresh, mut gpio_btn_previous, mut gpio_btn_next) =
+        (peripherals.GPIO5, peripherals.GPIO4, peripherals.GPIO3);
+
+    // Read all three buttons ASAP so we capture the press even if the user
+    // releases quickly after powering the device out of deep sleep.
+    let refresh_held = Input::new(
+        gpio_btn_refresh.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    )
+    .is_low();
+    let previous_held = Input::new(
+        gpio_btn_previous.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    )
+    .is_low();
+    let next_held = Input::new(
+        gpio_btn_next.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    )
+    .is_low();
+
+    // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
+    // and clear it immediately so stale bits don't carry into the next cycle.
+    // The latch is authoritative because it captures the pin state at the
+    // exact moment of wake — even a sub-millisecond tap is recorded, whereas
+    // the current-level read above misses anything released during the
+    // ~300 ms bootloader window.
+    let button_bits = (1u32 << gpio_btn_refresh.number())
+        | (1u32 << gpio_btn_previous.number())
+        | (1u32 << gpio_btn_next.number());
+    let rtc_gpio_int_mask = read_and_clear_rtc_gpio_wake_status(button_bits);
+
+    let refresh_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_refresh.number())) != 0;
+    let previous_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_previous.number())) != 0;
+    let next_latched = (rtc_gpio_int_mask & (1u32 << gpio_btn_next.number())) != 0;
+
+    let wake_action = epd_photoframe::app::determine_wake_action(
+        reset_reason,
+        wake_reason,
+        refresh_latched,
+        previous_latched,
+        next_latched,
+    );
+
+    let rtc = esp_hal::rtc_cntl::Rtc::new(peripherals.LPWR);
+    let time_since_boot = rtc.time_since_power_up();
+    println!(
+        "Device booting up - reset={reset_reason:?} wake={wake_reason:?} action={wake_action:?} \
+         latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
+         held[refresh={refresh_held} previous={previous_held} next={next_held}] \
+         uptime={time_since_boot:?}"
+    );
+    println!(
+        "RTC CURRENT_URL: {:?}",
+        epd_photoframe::normal_mode::CURRENT_URL.get().as_deref()
+    );
+    println!(
+        "RTC REDIRECT_URL: {:?}",
+        epd_photoframe::normal_mode::REDIRECT_URL.get().as_deref()
+    );
+
+    esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 73744);
+    esp_alloc::psram_allocator!(
+        peripherals.PSRAM,
+        esp_hal::psram,
+        esp_hal::psram::PsramConfig {
+            mode: esp_hal::psram::PsramMode::OctalSpi,
+            ..Default::default()
+        }
+    );
+
+    // Load runtime configuration from NVS. A fresh / blank partition is
+    // not an error (esp-nvs treats all-0xFF as "no entries yet"), so the
+    // only ways `Config::new` fails are programming bugs (wrong partition
+    // offset/size) or actual flash hardware trouble — panicking there is
+    // the right call. A missing *key* is different: that's how we detect
+    // "needs configuring" and short-circuit into config mode below.
+    let config =
+        Config::new(peripherals.FLASH).expect("NVS init failed — check partition table and flash");
+    if config.is_configured().unwrap_or(false) {
+        let has_hint = config.get_wifi_hint().ok().flatten().is_some();
+        println!(
+            "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
+            config
+                .get_wifi_ssid()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
+            config
+                .get_wifi_password()
+                .ok()
+                .flatten()
+                .map(|p| p.len())
+                .unwrap_or(0),
+            config
+                .get_image_url()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
+            if has_hint { "present" } else { "none" },
+        );
+    } else {
+        println!("NVS config incomplete; forcing config mode");
+    }
+
+    let timg0 = TimerGroup::new(peripherals.TIMG0);
+    let sw_ints =
+        esp_hal::interrupt::software::SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
+    esp_rtos::start(timg0.timer0, sw_ints.software_interrupt0);
+
+    // Status LED is on a different GPIO per device.
+    let led_pin = peripherals.GPIO48;
+    spawner.spawn(blink_task(Output::new(led_pin, Level::Low, OutputConfig::default())).unwrap());
+
+    // One task that drives both per-wake sensor reads (battery ADC +
+    // SHT40 over I²C0) concurrently via `join`. By the time the URL
+    // is being built in `normal_mode::run`, both signals have been
+    // populated — the 10 ms ADC settle + the 10 ms SHT40 conversion
+    // happen alongside the ~1.3 s WiFi association, so the `wait()`s
+    // are essentially free.
+    let i2c0 =
+        esp_hal::i2c::master::I2c::new(peripherals.I2C0, esp_hal::i2c::master::Config::default())
+            .unwrap()
+            .with_sda(peripherals.GPIO19)
+            .with_scl(peripherals.GPIO20)
+            .into_async();
+
+    // PPK2 measurement mode: park the SY6974B charger in HIZ before
+    // anything else runs so the system rail spends as little time as
+    // possible drawing through VBUS. This must happen after I²C0 is up
+    // (the chip lives on this bus) but before any code that depends on
+    // the BAT-only power path being established.
+    #[cfg(feature = "disable_charger")]
+    let i2c0 = epd_photoframe::sy6974b::enter_measurement_mode(i2c0).await;
+
+    spawner.spawn(
+        epd_photoframe::normal_mode::sensor_task(
+            Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
+            peripherals.ADC1,
+            peripherals.GPIO1,
+            i2c0,
+            true,
+        )
+        .unwrap(),
+    );
+
+    // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
+    let epd_spi_bus = Spi::new(
+        peripherals.SPI2,
+        SpiConfig::default()
+            .with_write_bit_order(esp_hal::spi::BitOrder::MsbFirst)
+            .with_frequency(esp_hal::time::Rate::from_mhz(20))
+            .with_mode(SpiMode::_0),
+    )
+    .unwrap();
+
+    let mut epd_spi_bus = epd_spi_bus
+        .with_sck(peripherals.GPIO7)
+        .with_miso(peripherals.GPIO8)
+        .with_mosi(peripherals.GPIO9)
+        .into_async();
+
+    let epd = T133A01::new(
+        &mut epd_spi_bus,
+        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
+        Output::new(peripherals.GPIO2, Level::Low, OutputConfig::default()),
+        Input::new(
+            peripherals.GPIO13,
+            InputConfig::default().with_pull(Pull::Up),
+        ),
+        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
+        Output::new(peripherals.GPIO38, Level::Low, OutputConfig::default()),
+        // GPIO12: TFT_EN board rail (E1004 only); high while the panel is powered.
+        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
+    );
+
+    // Unified hardware context handed off to whichever top-level flow
+    // wins (`panic_mode::run`, `run_normal_boot`, then `normal_mode::run`
+    // or `config_mode::run`). The panel's board-level enable rail
+    // (E1004's TFT_EN; no-op on E1002 / E1001) stays *off* here —
+    // each flow asserts it (idempotently) before its own first panel
+    // I/O, so the rail is only powered when the panel is about to be
+    // touched.
+    let hw = HardwareCtx {
+        spawner,
+        rtc,
+        wake_action,
+        wifi: peripherals.WIFI,
+        refresh_button_label: "Refresh button",
+        has_sy6974b: true,
+        gpio_btn_refresh: gpio_btn_refresh.degrade(),
+        gpio_btn_previous: gpio_btn_previous.degrade(),
+        gpio_btn_next: gpio_btn_next.degrade(),
+        spi_bus: epd_spi_bus,
+        epd,
+        buzzer: epd_photoframe::buzzer::Buzzer::new(peripherals.LEDC, peripherals.GPIO45),
+    };
+
+    // --- Panic-render fast path -----------------------------------------
+    //
+    // If the previous boot ended in a panic, the release-build panic
+    // handler stashed the formatted message in `panic_mode::PANIC_MSG`
+    // and soft-reset. `take_pending_message` clears the slot, so a
+    // re-panic during render falls back to a normal cycle on the next
+    // boot rather than looping. Skips white pre-flash, WiFi, sensors,
+    // and the config-mode race: just renders the message and deep-
+    // sleeps, wakeable by timer or button so the user can retry
+    // without a power-cycle. The `else` branch holds the rest of
+    // `main()` so the divergence is structural — once we go into
+    // `panic_mode::run` we never come back.
+    epd_photoframe::app::run(hw, config).await
+}

--- a/src/config_mode.rs
+++ b/src/config_mode.rs
@@ -6,8 +6,11 @@
 //! instructions on the panel. On form submission, persist the values
 //! to NVS and trigger a software reset back into the normal flow.
 
+use alloc::boxed::Box;
 use alloc::format;
 use alloc::string::String;
+use core::future::Future;
+use core::pin::Pin;
 
 use embassy_net::Stack;
 use embassy_time::{Duration, Timer};
@@ -18,13 +21,19 @@ use esp_println::println;
 use crate::button::wait_for_press;
 use crate::config::Config;
 use crate::config_image;
-use crate::hardware::{EpdColor, EpdPanel, HardwareCtx};
+use crate::hardware::HardwareCtx;
 use crate::net_resources::NETWORK_RESOURCES;
 use crate::panel::{Panel, PanelColor};
 
 mod portal;
 
-pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
+pub async fn run<P>(ctx: HardwareCtx<P>, mut nvs: Config<'static>) -> !
+where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>> + 'static,
+    P::Color: PanelColor + 'static,
+    P::Error: core::fmt::Debug,
+    P::InitMode: core::fmt::Debug,
+{
     let HardwareCtx {
         spawner,
         wifi,
@@ -32,6 +41,7 @@ pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
         spi_bus,
         epd,
         mut buzzer,
+        refresh_button_label,
         ..
     } = ctx;
 
@@ -101,7 +111,16 @@ pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
     spawner.spawn(net_task(net_runner).unwrap());
     spawner.spawn(dhcp_server_task(net_stack).unwrap());
     spawner.spawn(dns_hijack_task(net_stack).unwrap());
-    spawner.spawn(portal::web_task(net_stack, stored_ssid, stored_url, password_is_set).unwrap());
+    spawner.spawn(
+        portal::web_task(
+            net_stack,
+            stored_ssid,
+            stored_url,
+            password_is_set,
+            refresh_button_label,
+        )
+        .unwrap(),
+    );
 
     // Hand the panel rendering off to its own task — composing the QR
     // + instructions bitmap and driving the ~20 s e-ink refresh all run
@@ -109,7 +128,15 @@ pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
     // waiting for them. The software reset at the end of this function
     // cleanly interrupts the driver mid-update if the user wins the
     // race; the next boot's own panel reset recovers.
-    spawner.spawn(panel_render_task(spi_bus, epd, ap_ssid).unwrap());
+    spawner.spawn(
+        panel_render_task(Box::pin(panel_render(
+            spi_bus,
+            epd,
+            ap_ssid,
+            refresh_button_label,
+        )))
+        .unwrap(),
+    );
 
     // Two exits from config mode:
     //   - the HTTP portal fires `SAVE_SIGNAL` with the submitted form →
@@ -176,13 +203,25 @@ async fn net_task(mut runner: embassy_net::Runner<'static, esp_radio::wifi::Inte
 /// Render the QR + instructions frame for configuration mode and drive
 /// the e-ink refresh, off the hot path so the save / Refresh race in
 /// `run` isn't blocked for ~20 s waiting for the panel to settle.
+type PanelRenderFuture = Pin<Box<dyn Future<Output = ()> + 'static>>;
+
 #[embassy_executor::task]
-async fn panel_render_task(
+async fn panel_render_task(panel_render: PanelRenderFuture) {
+    panel_render.await;
+}
+
+async fn panel_render<P>(
     mut spi_bus: Spi<'static, esp_hal::Async>,
-    mut epd: EpdPanel,
+    mut epd: P,
     ap_ssid: String,
-) {
-    let (panel_width, panel_height) = (EpdPanel::WIDTH, EpdPanel::HEIGHT);
+    refresh_button_label: &'static str,
+) where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>> + 'static,
+    P::Color: PanelColor + 'static,
+    P::Error: core::fmt::Debug,
+    P::InitMode: core::fmt::Debug,
+{
+    let (panel_width, panel_height) = (P::WIDTH, P::HEIGHT);
     // The QR encodes a WiFi-join URI so most phones' camera-app scanners
     // offer a one-tap "Join network" action; the text below it gives the
     // SSID (for manual entry) and the portal URL as a fallback for users
@@ -196,12 +235,11 @@ async fn panel_render_task(
          Then open: http://192.168.4.1/\n\
          \n\
          Press the {} to exit without saving.",
-        ap_ssid,
-        portal::REFRESH_BUTTON_LABEL
+        ap_ssid, refresh_button_label
     );
     println!("Rendering config screen with QR: {}", qr_payload);
     let frame =
-        config_image::render::<EpdColor>(panel_width, panel_height, &qr_payload, &instructions);
+        config_image::render::<P::Color>(panel_width, panel_height, &qr_payload, &instructions);
 
     // Bring the panel's enable rail up before any panel I/O.
     // Idempotent — fine if the white pre-flash already raised it.
@@ -214,13 +252,13 @@ async fn panel_render_task(
     // The config-mode frame is rendered with `BLACK` + `WHITE` only
     // (QR plus instruction text); ask the panel which init mode covers
     // that. On E1001 that's `Bw`; single-mode panels return `()`.
-    let init_mode = EpdPanel::init_mode_for_palette([EpdColor::BLACK, EpdColor::WHITE]);
+    let init_mode = P::init_mode_for_palette([P::Color::BLACK, P::Color::WHITE]);
     epd.init(&mut spi_bus, init_mode).await.unwrap();
     println!("Power on");
     epd.power_on(&mut spi_bus).await.unwrap();
     println!("Update frame (QR)");
     let data = (0..(panel_width * panel_height)).map(|idx| {
-        let (x, y) = EpdPanel::output_index_to_image_xy(idx);
+        let (x, y) = P::output_index_to_image_xy(idx);
         frame[y * panel_width + x]
     });
     epd.update_frame(&mut spi_bus, data).await.unwrap();

--- a/src/config_mode/portal.rs
+++ b/src/config_mode/portal.rs
@@ -28,16 +28,6 @@ use esp_println::println;
 /// *not* the sentinel is therefore a malformed submission.
 pub const PASSWORD_SENTINEL: &str = "___________________________unchanged___________________________unchanged___________________________";
 
-/// Device-specific label for the Refresh button — on the E1001 / E1002
-/// it's the unmarked green button, so we spell that out in the
-/// instructions; on the E1004 the button is clearly iconed and needs
-/// no qualifier. Used both in the portal HTML and in the panel
-/// instructions rendered by `config_mode`.
-#[cfg(any(feature = "e1001", feature = "e1002"))]
-pub const REFRESH_BUTTON_LABEL: &str = "Refresh button (green)";
-#[cfg(feature = "e1004")]
-pub const REFRESH_BUTTON_LABEL: &str = "Refresh button";
-
 const FORM_TEMPLATE: &str = include_str!("form.html");
 const SAVED_HTML: &[u8] = include_bytes!("saved.html");
 
@@ -98,7 +88,13 @@ pub static SAVE_SIGNAL: Signal<CriticalSectionRawMutex, PortalCreds> = Signal::n
 /// The password field is echoed back verbatim (modulo escaping) — the
 /// user and the browser already saw it when it was typed, so echoing
 /// it on a re-render leaks nothing and spares them a retype.
-fn render_form(ssid: &str, password: &str, url: &str, error: Option<&str>) -> String {
+fn render_form(
+    ssid: &str,
+    password: &str,
+    url: &str,
+    error: Option<&str>,
+    refresh_button_label: &str,
+) -> String {
     let error_html = match error {
         Some(msg) => alloc::format!(r#"<p class="error">{}</p>"#, html_attr_escape(msg)),
         None => String::new(),
@@ -108,7 +104,7 @@ fn render_form(ssid: &str, password: &str, url: &str, error: Option<&str>) -> St
         .replace("{ssid}", &html_attr_escape(ssid))
         .replace("{password}", &html_attr_escape(password))
         .replace("{url}", &html_attr_escape(url))
-        .replace("{refresh_hint}", REFRESH_BUTTON_LABEL)
+        .replace("{refresh_hint}", refresh_button_label)
 }
 
 /// Minimal HTML escape for values going into a double-quoted attribute.
@@ -136,6 +132,7 @@ pub struct PortalHandler {
     default_ssid: String,
     default_url: String,
     default_password_is_set: bool,
+    refresh_button_label: &'static str,
 }
 
 impl Handler for PortalHandler {
@@ -162,7 +159,7 @@ impl Handler for PortalHandler {
         if method == Method::Post {
             let path_is_save = conn.headers()?.path == "/save";
             if path_is_save {
-                return handle_save(conn, content_len).await;
+                return handle_save(conn, content_len, self.refresh_button_label).await;
             }
         }
         // Everything else (including all captive-portal probes) returns
@@ -180,6 +177,7 @@ impl Handler for PortalHandler {
             default_password,
             &self.default_url,
             None,
+            self.refresh_button_label,
         );
         write_form(conn, &html, 200, "OK").await
     }
@@ -188,6 +186,7 @@ impl Handler for PortalHandler {
 async fn handle_save<T, const N: usize>(
     conn: &mut Connection<'_, T, N>,
     content_len: usize,
+    refresh_button_label: &'static str,
 ) -> Result<(), Error<T::Error>>
 where
     T: Read + Write + edge_nal::TcpSplit,
@@ -210,7 +209,13 @@ where
         Some(r) => r,
         None => {
             println!("portal: form body did not parse");
-            let html = render_form("", "", "", Some(FormError::Unparseable.message()));
+            let html = render_form(
+                "",
+                "",
+                "",
+                Some(FormError::Unparseable.message()),
+                refresh_button_label,
+            );
             return write_form(conn, &html, 400, "Bad Request").await;
         }
     };
@@ -241,7 +246,13 @@ where
         }
         Err(err) => {
             println!("portal: validation failed: {}", err.message());
-            let html = render_form(&raw.ssid, &raw.password, &raw.url, Some(err.message()));
+            let html = render_form(
+                &raw.ssid,
+                &raw.password,
+                &raw.url,
+                Some(err.message()),
+                refresh_button_label,
+            );
             write_form(conn, &html, 400, "Bad Request").await
         }
     }
@@ -361,7 +372,13 @@ fn url_decode(s: &str) -> String {
 /// concurrent handler tasks cover phones that pipeline captive-portal
 /// probes without burning too much RAM on buffers.
 #[embassy_executor::task]
-pub async fn web_task(stack: Stack<'static>, ssid: String, url: String, password_is_set: bool) {
+pub async fn web_task(
+    stack: Stack<'static>,
+    ssid: String,
+    url: String,
+    password_is_set: bool,
+    refresh_button_label: &'static str,
+) {
     use core::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     use edge_nal::TcpBind;
@@ -379,6 +396,7 @@ pub async fn web_task(stack: Stack<'static>, ssid: String, url: String, password
         default_ssid: ssid,
         default_url: url,
         default_password_is_set: password_is_set,
+        refresh_button_label,
     };
     println!("HTTP portal listening on :80");
     loop {

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -3,7 +3,6 @@
 //! concrete panel type; the common firmware path only requires that it
 //! implements [`crate::panel::Panel`].
 
-use embassy_executor::Spawner;
 use esp_hal::gpio::AnyPin;
 use esp_hal::spi::master::Spi;
 
@@ -47,53 +46,11 @@ impl WakeAction {
     }
 }
 
-/// Hardware and one-shot peripherals handed from the device-specific binary
-/// into the common app startup path.
-pub struct AppHardware<P> {
-    pub spawner: Spawner,
-    pub reset_reason: Option<esp_hal::rtc_cntl::SocResetReason>,
-    pub wake_reason: esp_hal::system::SleepSource,
-    pub wifi: esp_hal::peripherals::WIFI<'static>,
-    pub flash: esp_hal::peripherals::FLASH<'static>,
-    pub psram: esp_hal::peripherals::PSRAM<'static>,
-    pub lpwr: esp_hal::peripherals::LPWR<'static>,
-    pub timg0: esp_hal::peripherals::TIMG0<'static>,
-    pub sw_interrupt: esp_hal::peripherals::SW_INTERRUPT<'static>,
-    pub status_led: AnyPin<'static>,
-    pub refresh_button_label: &'static str,
-    pub has_sy6974b: bool,
-
-    pub i2c0: esp_hal::peripherals::I2C0<'static>,
-    pub gpio_i2c_sda: esp_hal::peripherals::GPIO19<'static>,
-    pub gpio_i2c_scl: esp_hal::peripherals::GPIO20<'static>,
-    pub adc1: esp_hal::peripherals::ADC1<'static>,
-    pub gpio_battery_enable: esp_hal::peripherals::GPIO21<'static>,
-    pub gpio_battery_sense: esp_hal::peripherals::GPIO1<'static>,
-
-    /// Button pins; held so the normal flow can hand them to
-    /// `RtcioWakeupSource` as deep-sleep wake sources.
-    pub gpio_btn_refresh: AnyPin<'static>,
-    pub gpio_btn_previous: AnyPin<'static>,
-    pub gpio_btn_next: AnyPin<'static>,
-
-    /// Pre-built SPI bus (SCK/MOSI, plus MISO on E1004) and pre-built EPD
-    /// driver holding its CS/BUSY/DC/RST (and EN, on E1004) pins. The
-    /// driver implements [`crate::panel::Panel`] including `enable` /
-    /// `disable` for the board-level TFT rail on devices that have one.
-    pub spi_bus: Spi<'static, esp_hal::Async>,
-    pub epd: P,
-
-    /// Buzzer driver pre-built around the GPIO45 piezo + LEDC peripheral.
-    /// Always populated — both E1002 and E1004 have the piezo on the
-    /// same pin per Seeed's E10xx ESPHome reference.
-    pub buzzer: Buzzer,
-}
-
 /// Everything both `config_mode::run` and `normal_mode::run` need. The panel
 /// driver is pre-built by the selected binary, so the shared modes do not need
 /// cfg gates for pin counts or panel-model-specific construction.
 pub struct HardwareCtx<P> {
-    pub spawner: Spawner,
+    pub spawner: embassy_executor::Spawner,
     pub rtc: esp_hal::rtc_cntl::Rtc<'static>,
     pub wake_action: WakeAction,
     pub wifi: esp_hal::peripherals::WIFI<'static>,

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -47,6 +47,48 @@ impl WakeAction {
     }
 }
 
+/// Hardware and one-shot peripherals handed from the device-specific binary
+/// into the common app startup path.
+pub struct AppHardware<P> {
+    pub spawner: Spawner,
+    pub reset_reason: Option<esp_hal::rtc_cntl::SocResetReason>,
+    pub wake_reason: esp_hal::system::SleepSource,
+    pub wifi: esp_hal::peripherals::WIFI<'static>,
+    pub flash: esp_hal::peripherals::FLASH<'static>,
+    pub psram: esp_hal::peripherals::PSRAM<'static>,
+    pub lpwr: esp_hal::peripherals::LPWR<'static>,
+    pub timg0: esp_hal::peripherals::TIMG0<'static>,
+    pub sw_interrupt: esp_hal::peripherals::SW_INTERRUPT<'static>,
+    pub status_led: AnyPin<'static>,
+    pub refresh_button_label: &'static str,
+    pub has_sy6974b: bool,
+
+    pub i2c0: esp_hal::peripherals::I2C0<'static>,
+    pub gpio_i2c_sda: esp_hal::peripherals::GPIO19<'static>,
+    pub gpio_i2c_scl: esp_hal::peripherals::GPIO20<'static>,
+    pub adc1: esp_hal::peripherals::ADC1<'static>,
+    pub gpio_battery_enable: esp_hal::peripherals::GPIO21<'static>,
+    pub gpio_battery_sense: esp_hal::peripherals::GPIO1<'static>,
+
+    /// Button pins; held so the normal flow can hand them to
+    /// `RtcioWakeupSource` as deep-sleep wake sources.
+    pub gpio_btn_refresh: AnyPin<'static>,
+    pub gpio_btn_previous: AnyPin<'static>,
+    pub gpio_btn_next: AnyPin<'static>,
+
+    /// Pre-built SPI bus (SCK/MOSI, plus MISO on E1004) and pre-built EPD
+    /// driver holding its CS/BUSY/DC/RST (and EN, on E1004) pins. The
+    /// driver implements [`crate::panel::Panel`] including `enable` /
+    /// `disable` for the board-level TFT rail on devices that have one.
+    pub spi_bus: Spi<'static, esp_hal::Async>,
+    pub epd: P,
+
+    /// Buzzer driver pre-built around the GPIO45 piezo + LEDC peripheral.
+    /// Always populated — both E1002 and E1004 have the piezo on the
+    /// same pin per Seeed's E10xx ESPHome reference.
+    pub buzzer: Buzzer,
+}
+
 /// Everything both `config_mode::run` and `normal_mode::run` need. The panel
 /// driver is pre-built by the selected binary, so the shared modes do not need
 /// cfg gates for pin counts or panel-model-specific construction.

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -1,61 +1,13 @@
-//! Shared hardware container handed between `main()` and whichever mode
-//! runs this boot (config vs. normal). Keeping it here means neither mode
-//! needs to cfg-gate on the panel model or care about pin counts — they
-//! see the same `EpdPanel` alias and the same field set.
+//! Shared hardware container handed between the device-specific binary and
+//! whichever mode runs this boot (config vs. normal). The binary chooses the
+//! concrete panel type; the common firmware path only requires that it
+//! implements [`crate::panel::Panel`].
 
 use embassy_executor::Spawner;
-use esp_hal::gpio::{AnyPin, Output};
+use esp_hal::gpio::AnyPin;
 use esp_hal::spi::master::Spi;
 
 use crate::buzzer::Buzzer;
-use crate::panel::Panel;
-
-#[cfg(feature = "e1002")]
-use crate::panel::gdep073e01::Gdep073e01;
-#[cfg(feature = "e1001")]
-use crate::panel::gdey075t7::Gdey075t7;
-#[cfg(feature = "e1004")]
-use crate::panel::t133a01::T133A01;
-
-/// Fully-specialised type of the built panel driver. All variants
-/// implement the [`crate::panel::Panel`] trait so the rest of the firmware
-/// can drive the panel without caring which model it is.
-#[cfg(feature = "e1001")]
-pub type EpdPanel = Gdey075t7<
-    Spi<'static, esp_hal::Async>,
-    Output<'static>,
-    esp_hal::gpio::Input<'static>,
-    Output<'static>,
-    Output<'static>,
->;
-#[cfg(feature = "e1002")]
-pub type EpdPanel = Gdep073e01<
-    Spi<'static, esp_hal::Async>,
-    Output<'static>,
-    esp_hal::gpio::Input<'static>,
-    Output<'static>,
-    Output<'static>,
->;
-#[cfg(feature = "e1004")]
-pub type EpdPanel = T133A01<
-    Spi<'static, esp_hal::Async>,
-    Output<'static>, // cs_master
-    Output<'static>, // cs_slave
-    esp_hal::gpio::Input<'static>,
-    Output<'static>, // dc
-    Output<'static>, // rst
-    Output<'static>, // en (TFT_EN rail)
->;
-
-/// The panel's pixel colour type. Aliased through the `Panel` trait
-/// projection so callers can write `EpdColor::WHITE` etc. without
-/// hard-coding `Spectra6Color` / `Gray2` per device.
-pub type EpdColor = <EpdPanel as Panel<Spi<'static, esp_hal::Async>>>::Color;
-
-/// The panel's per-init mode selector — see [`Panel::InitMode`]. Most
-/// devices use `()` (single mode); E1001's UC8179 driver exposes
-/// `Bw` / `FourLevel`.
-pub type EpdInitMode = <EpdPanel as Panel<Spi<'static, esp_hal::Async>>>::InitMode;
 
 /// What the user (or the wake timer) wants us to do this cycle. Consumed
 /// by the normal flow to pick an `action=` query-string fragment and to
@@ -95,14 +47,16 @@ impl WakeAction {
     }
 }
 
-/// Everything both `config_mode::run` and `main_normal` need. The panel
-/// driver is pre-built (aliased as `EpdPanel` above) so neither mode needs
-/// cfg gates for pin counts or panel-model-specific types.
-pub struct HardwareCtx {
+/// Everything both `config_mode::run` and `normal_mode::run` need. The panel
+/// driver is pre-built by the selected binary, so the shared modes do not need
+/// cfg gates for pin counts or panel-model-specific construction.
+pub struct HardwareCtx<P> {
     pub spawner: Spawner,
     pub rtc: esp_hal::rtc_cntl::Rtc<'static>,
     pub wake_action: WakeAction,
     pub wifi: esp_hal::peripherals::WIFI<'static>,
+    pub refresh_button_label: &'static str,
+    pub has_sy6974b: bool,
 
     /// Button pins; held so the normal flow can hand them to
     /// `RtcioWakeupSource` as deep-sleep wake sources.
@@ -115,7 +69,7 @@ pub struct HardwareCtx {
     /// driver implements [`crate::panel::Panel`] including `enable` /
     /// `disable` for the board-level TFT rail on devices that have one.
     pub spi_bus: Spi<'static, esp_hal::Async>,
-    pub epd: EpdPanel,
+    pub epd: P,
 
     /// Buzzer driver pre-built around the GPIO45 piezo + LEDC peripheral.
     /// Always populated — both E1002 and E1004 have the piezo on the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,7 @@
 #![no_std]
 extern crate alloc;
 
-#[cfg(all(feature = "e1001", feature = "e1002"))]
-compile_error!("features `e1001` and `e1002` are mutually exclusive");
-#[cfg(all(feature = "e1001", feature = "e1004"))]
-compile_error!("features `e1001` and `e1004` are mutually exclusive");
-#[cfg(all(feature = "e1002", feature = "e1004"))]
-compile_error!("features `e1002` and `e1004` are mutually exclusive");
-#[cfg(not(any(feature = "e1001", feature = "e1002", feature = "e1004")))]
-compile_error!("enable one of the device features: `e1001`, `e1002`, or `e1004`");
-
+pub mod app;
 pub mod battery;
 pub mod button;
 pub mod buzzer;

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -20,7 +20,7 @@ use crate::battery;
 use crate::button::wait_for_press;
 use crate::config::Config;
 use crate::error_image;
-use crate::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction};
+use crate::hardware::{HardwareCtx, WakeAction};
 use crate::panel::{Panel, PanelColor};
 use crate::rtc_persisted::RtcPersisted;
 use crate::sht40;
@@ -94,13 +94,15 @@ pub async fn sensor_task(
     adc1: esp_hal::peripherals::ADC1<'static>,
     battery_sense: esp_hal::peripherals::GPIO1<'static>,
     mut i2c0: esp_hal::i2c::master::I2c<'static, esp_hal::Async>,
+    read_power_status: bool,
 ) {
     let i2c_reads = async {
         let temp_humidity = sht40::read_temp_humidity(&mut i2c0).await;
-        #[cfg(feature = "e1004")]
-        let power_status = sy6974b::read_power_status(&mut i2c0).await;
-        #[cfg(not(feature = "e1004"))]
-        let power_status: Option<sy6974b::PowerStatus> = None;
+        let power_status = if read_power_status {
+            sy6974b::read_power_status(&mut i2c0).await
+        } else {
+            None
+        };
         (temp_humidity, power_status)
     };
     let (battery_mv, (temp_humidity, power_status)) = embassy_futures::join::join(
@@ -171,7 +173,13 @@ impl From<String> for FetchError {
 /// white pre-flash that `main()`'s `run_normal_boot` may have kicked
 /// off, then deep-sleep waking on either the `Refresh:` interval (or
 /// the fallback timer) or a button press.
-pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
+pub async fn run<P>(ctx: HardwareCtx<P>, mut config: Config<'static>) -> !
+where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>>,
+    P::Color: PanelColor,
+    P::Error: core::fmt::Debug,
+    P::InitMode: core::fmt::Debug,
+{
     let HardwareCtx {
         rtc,
         wake_action,
@@ -181,10 +189,11 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
         mut gpio_btn_next,
         mut spi_bus,
         mut epd,
+        has_sy6974b,
         ..
     } = ctx;
 
-    let (panel_width, panel_height) = (EpdPanel::WIDTH, EpdPanel::HEIGHT);
+    let (panel_width, panel_height) = (P::WIDTH, P::HEIGHT);
 
     // Figure out what to fetch this cycle. Start from whatever's in
     // RTC (defaulting to the NVS URL on cold boot) and adjust per the
@@ -250,7 +259,11 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
                 let battery_mv = BATTERY_MV.wait().await;
                 let battery_pct = battery::mv_to_percentage(battery_mv);
                 let temp_humidity = TEMP_HUMIDITY.wait().await;
-                let power_status = POWER_STATUS.wait().await;
+                let power_status = if has_sy6974b {
+                    POWER_STATUS.wait().await
+                } else {
+                    None
+                };
                 let fetch_url = url_util::set_query_variable(
                     base_url_ref,
                     "battery_mv",
@@ -297,7 +310,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
     // error path can still honour it. `try_decode_frame` returns
     // both the row-major frame and the actual PNG palette (sized to
     // `1 << bit_depth`) so the caller can pick a panel init mode.
-    let frame_result: Result<(Vec<EpdColor>, Vec<EpdColor>), String>;
+    let frame_result: Result<(Vec<P::Color>, Vec<P::Color>), String>;
     let hint: Option<RefreshHint>;
     match fetch_result {
         Ok((body, h)) => {
@@ -318,7 +331,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
     // absolute `Instant` so the time we then spend on the panel refresh
     // + UART flush is automatically subtracted from the sleep duration
     // when we compute it below.
-    let (frame, palette, wakeup_requested): (_, Vec<EpdColor>, embassy_time::Instant) =
+    let (frame, palette, wakeup_requested): (_, Vec<P::Color>, embassy_time::Instant) =
         match frame_result {
             Ok((frame, palette)) => {
                 match hint.as_ref().and_then(|h| h.url_override.as_deref()) {
@@ -371,7 +384,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
                 // so its effective palette is exactly those two colours.
                 (
                     error_image::render(panel_width, panel_height, &msg, Some(retry_in)),
-                    Vec::from([EpdColor::BLACK, EpdColor::WHITE]),
+                    Vec::from([P::Color::BLACK, P::Color::WHITE]),
                     wakeup,
                 )
             }
@@ -393,7 +406,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
     // present in the PNG palette (≈ half the SPI traffic + faster
     // waveform when the server-side content is already 1bpp).
     // Single-mode panels return `()` immediately without iterating.
-    let init_mode = EpdPanel::init_mode_for_palette(palette.iter().copied());
+    let init_mode = P::init_mode_for_palette(palette.iter().copied());
     println!("Init mode: {:?}", init_mode);
     let panel_update = async {
         // Bring the panel's enable rail up before any panel I/O.
@@ -409,7 +422,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
         epd.power_on(&mut spi_bus).await.unwrap();
         println!("Update frame");
         let data = (0..(panel_width * panel_height)).map(|idx| {
-            let (x, y) = EpdPanel::output_index_to_image_xy(idx);
+            let (x, y) = P::output_index_to_image_xy(idx);
             frame[y * panel_width + x]
         });
         epd.update_frame(&mut spi_bus, data).await.unwrap();

--- a/src/panic_mode.rs
+++ b/src/panic_mode.rs
@@ -28,7 +28,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use esp_println::println;
 
 use crate::error_image;
-use crate::hardware::{EpdColor, EpdPanel, HardwareCtx};
+use crate::hardware::HardwareCtx;
 use crate::panel::{Panel, PanelColor};
 use crate::rtc_persisted::RtcPersisted;
 use crate::uart::wait_for_tx_idle;
@@ -146,38 +146,12 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
     esp_hal::system::software_reset();
 }
 
-/// Drive the status LED high directly via the GPIO PAC. Wraps the
-/// PAC-mandated `unsafe` (svd2rust marks the W1TS field setters as
-/// `Unsafe` because it can't statically verify field semantics) in a
-/// safe helper — writing 1-bits to a write-1-to-set register only
-/// flips hardware status bits and can't violate memory safety.
-///
-/// Used from the panic handler's halt branch where the embassy
-/// executor isn't running, so we can't go through the normal
-/// `Output::set_high` path. If a panic fires before the LED pin has
-/// been configured as an output (very early boot), the OE write below
-/// is what actually enables it; the IO_MUX MCU function defaults to
-/// "GPIO" on these pins, so we don't need to touch IO_MUX.
+/// Placeholder for the panic handler's halt branch. The selected binary owns
+/// the status LED pin, so the shared panic path no longer pokes a device
+/// specific GPIO register directly.
 fn force_led_on() {
-    let gpio = esp_hal::peripherals::GPIO::regs();
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
-    {
-        // Status LED on GPIO6 — bit 6 of the lower bank.
-        const BIT: u32 = 1 << 6;
-        unsafe {
-            gpio.enable_w1ts().write(|w| w.bits(BIT));
-            gpio.out_w1ts().write(|w| w.bits(BIT));
-        }
-    }
-    #[cfg(feature = "e1004")]
-    {
-        // Status LED on GPIO48 — bit 16 of the upper bank (48 - 32).
-        const BIT: u32 = 1 << (48 - 32);
-        unsafe {
-            gpio.enable1_w1ts().write(|w| w.bits(BIT));
-            gpio.out1_w1ts().write(|w| w.bits(BIT));
-        }
-    }
+    // The device-specific LED pin now lives in the selected binary. Keep the
+    // panic path allocation/executor-free and skip forcing a board LED here.
 }
 
 /// Render the captured panic `message` on the panel as an error frame
@@ -196,7 +170,13 @@ fn force_led_on() {
 /// rendered frame also omits the "Will retry in …" line that
 /// transient-error frames carry, since there's nothing scheduled to
 /// retry.
-pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
+pub async fn run<P>(ctx: HardwareCtx<P>, message: &str) -> !
+where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>>,
+    P::Color: PanelColor,
+    P::Error: core::fmt::Debug,
+    P::InitMode: core::fmt::Debug,
+{
     let HardwareCtx {
         rtc,
         mut gpio_btn_refresh,
@@ -210,10 +190,10 @@ pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
     println!("PANIC_MSG present; rendering panic frame");
     println!("Panic: {}", message);
 
-    let panel_width = EpdPanel::WIDTH;
-    let panel_height = EpdPanel::HEIGHT;
-    let frame: Vec<EpdColor> = error_image::render(panel_width, panel_height, message, None);
-    let init_mode = EpdPanel::init_mode_for_palette([EpdColor::BLACK, EpdColor::WHITE]);
+    let panel_width = P::WIDTH;
+    let panel_height = P::HEIGHT;
+    let frame: Vec<P::Color> = error_image::render(panel_width, panel_height, message, None);
+    let init_mode = P::init_mode_for_palette([P::Color::BLACK, P::Color::WHITE]);
 
     // Bring the panel's enable rail up before any panel I/O.
     epd.enable().await.unwrap();
@@ -229,7 +209,7 @@ pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
     epd.update_frame(
         &mut spi_bus,
         (0..(panel_width * panel_height)).map(|idx| {
-            let (x, y) = EpdPanel::output_index_to_image_xy(idx);
+            let (x, y) = P::output_index_to_image_xy(idx);
             frame[y * panel_width + x]
         }),
     )


### PR DESCRIPTION
## Summary
- replace mutually exclusive e1001/e1002/e1004 feature selection with separate device binaries
- add a generic shared app entry that dispatches panic/config/normal modes after hardware setup
- keep config-mode panel rendering asynchronous via a boxed panel-render future task
- thread device-specific capabilities like refresh button label and SY6974B support through HardwareCtx

## Testing
- cargo check --bins
- cargo check --bins --features disable_charger