### PR TITLE
Make hardware context generic over panel

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -25,7 +25,7 @@ extern crate alloc;
 
 use epd_photoframe::config::Config;
 use epd_photoframe::config_mode;
-use epd_photoframe::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction};
+use epd_photoframe::hardware::{HardwareCtx, WakeAction};
 use epd_photoframe::panel::{Panel, PanelColor};
 use epd_photoframe::panic_mode;
 
@@ -223,14 +223,24 @@ async fn main(spawner: Spawner) -> ! {
         let has_hint = config.get_wifi_hint().ok().flatten().is_some();
         println!(
             "Config in use: wifi.ssid={:?} wifi.pass=<{} chars> image.url={:?} wifi.hint={}",
-            config.get_wifi_ssid().ok().flatten().as_deref().unwrap_or(""),
+            config
+                .get_wifi_ssid()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
             config
                 .get_wifi_password()
                 .ok()
                 .flatten()
                 .map(|p| p.len())
                 .unwrap_or(0),
-            config.get_image_url().ok().flatten().as_deref().unwrap_or(""),
+            config
+                .get_image_url()
+                .ok()
+                .flatten()
+                .as_deref()
+                .unwrap_or(""),
             if has_hint { "present" } else { "none" },
         );
     } else {
@@ -389,10 +399,10 @@ async fn main(spawner: Spawner) -> ! {
 /// clean two-arm `if let … else …` at the call site rather than
 /// "one arm calls a `-> !` function and the rest of the function
 /// implicitly only runs on the other arm".
-async fn run_normal_boot(
-    mut hw: HardwareCtx,
-    config: Config<'static>,
-) -> ! {
+async fn run_normal_boot<P>(mut hw: HardwareCtx<P>, config: Config<'static>) -> !
+where
+    P: Panel<Spi<'static, esp_hal::Async>>,
+{
     // Past the panic-render decision: any panic from here on is
     // happening in a "normal" cycle, so the handler is allowed to
     // stash + soft-reset (release builds) instead of halting. See
@@ -419,7 +429,7 @@ async fn run_normal_boot(
         println!("Init");
         // Ask the panel which init mode covers an all-white palette;
         // on E1001 that's `Bw`, single-mode panels return `()`.
-        let init_mode = EpdPanel::init_mode_for_palette([EpdColor::WHITE]);
+        let init_mode = P::init_mode_for_palette([P::Color::WHITE]);
         hw.epd.init(&mut hw.spi_bus, init_mode).await.unwrap();
         println!("Power on");
         hw.epd.power_on(&mut hw.spi_bus).await.unwrap();
@@ -427,7 +437,7 @@ async fn run_normal_boot(
         hw.epd
             .update_frame(
                 &mut hw.spi_bus,
-                (0..(EpdPanel::WIDTH * EpdPanel::HEIGHT)).map(|_| EpdColor::WHITE),
+                (0..(P::WIDTH * P::HEIGHT)).map(|_| P::Color::WHITE),
             )
             .await
             .unwrap();

--- a/src/config_mode.rs
+++ b/src/config_mode.rs
@@ -18,13 +18,16 @@ use esp_println::println;
 use crate::button::wait_for_press;
 use crate::config::Config;
 use crate::config_image;
-use crate::hardware::{EpdColor, EpdPanel, HardwareCtx};
+use crate::hardware::HardwareCtx;
 use crate::net_resources::NETWORK_RESOURCES;
 use crate::panel::{Panel, PanelColor};
 
 mod portal;
 
-pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
+pub async fn run<P>(ctx: HardwareCtx<P>, mut nvs: Config<'static>) -> !
+where
+    P: Panel<Spi<'static, esp_hal::Async>>,
+{
     let HardwareCtx {
         spawner,
         wifi,
@@ -103,69 +106,72 @@ pub async fn run(ctx: HardwareCtx, mut nvs: Config<'static>) -> ! {
     spawner.spawn(dns_hijack_task(net_stack).unwrap());
     spawner.spawn(portal::web_task(net_stack, stored_ssid, stored_url, password_is_set).unwrap());
 
-    // Hand the panel rendering off to its own task — composing the QR
-    // + instructions bitmap and driving the ~20 s e-ink refresh all run
-    // in the background so a fast Save / Refresh press isn't blocked
-    // waiting for them. The software reset at the end of this function
-    // cleanly interrupts the driver mid-update if the user wins the
-    // race; the next boot's own panel reset recovers.
-    spawner.spawn(panel_render_task(spi_bus, epd, ap_ssid).unwrap());
+    // Run panel rendering alongside the save / Refresh race. If panel
+    // rendering finishes first, config mode keeps serving the portal; if
+    // the user exits first, software reset interrupts the render and the
+    // next boot's own panel reset recovers.
+    let panel_rendering = panel_render_task(spi_bus, epd, ap_ssid);
 
-    // Two exits from config mode:
-    //   - the HTTP portal fires `SAVE_SIGNAL` with the submitted form →
-    //     persist to NVS, reset.
-    //   - the user presses the Refresh button → don't touch NVS, reset
-    //     anyway (next boot lands in normal mode with the existing
-    //     creds).
-    // A failure to write NVS is logged but we reset regardless: either
-    // partial success lands new values for the next boot, or NVS is
-    // still incomplete and we re-enter config mode for a retry. Either
-    // beats silently hanging after the user hit "Save".
-    println!("Config mode ready — awaiting save or Refresh press.");
-    let mut refresh_input =
-        Input::new(gpio_btn_refresh, InputConfig::default().with_pull(Pull::Up));
-    let decision = embassy_futures::select::select(
-        portal::SAVE_SIGNAL.wait(),
-        wait_for_press(&mut refresh_input, Duration::from_millis(50)),
-    )
-    .await;
-    match decision {
-        embassy_futures::select::Either::First(creds) => {
-            println!(
-                "Saving config to NVS: ssid={:?}, url={:?}, password={}",
-                creds.ssid,
-                creds.url,
-                if creds.password.is_some() {
-                    "updated"
-                } else {
-                    "unchanged"
+    let wait_and_save = async {
+        // Two exits from config mode:
+        //   - the HTTP portal fires `SAVE_SIGNAL` with the submitted form →
+        //     persist to NVS, reset.
+        //   - the user presses the Refresh button → don't touch NVS, reset
+        //     anyway (next boot lands in normal mode with the existing
+        //     creds).
+        // A failure to write NVS is logged but we reset regardless: either
+        // partial success lands new values for the next boot, or NVS is
+        // still incomplete and we re-enter config mode for a retry. Either
+        // beats silently hanging after the user hit "Save".
+        println!("Config mode ready — awaiting save or Refresh press.");
+        let mut refresh_input =
+            Input::new(gpio_btn_refresh, InputConfig::default().with_pull(Pull::Up));
+        let decision = embassy_futures::select::select(
+            portal::SAVE_SIGNAL.wait(),
+            wait_for_press(&mut refresh_input, Duration::from_millis(50)),
+        )
+        .await;
+        match decision {
+            embassy_futures::select::Either::First(creds) => {
+                println!(
+                    "Saving config to NVS: ssid={:?}, url={:?}, password={}",
+                    creds.ssid,
+                    creds.url,
+                    if creds.password.is_some() {
+                        "updated"
+                    } else {
+                        "unchanged"
+                    }
+                );
+                if let Err(e) = nvs.set_wifi_ssid(&creds.ssid) {
+                    println!("WARNING: failed to write wifi.ssid: {:?}", e);
                 }
-            );
-            if let Err(e) = nvs.set_wifi_ssid(&creds.ssid) {
-                println!("WARNING: failed to write wifi.ssid: {:?}", e);
-            }
-            if let Some(pw) = creds.password.as_deref() {
-                if let Err(e) = nvs.set_wifi_password(pw) {
-                    println!("WARNING: failed to write wifi.pass: {:?}", e);
+                if let Some(pw) = creds.password.as_deref() {
+                    if let Err(e) = nvs.set_wifi_password(pw) {
+                        println!("WARNING: failed to write wifi.pass: {:?}", e);
+                    }
                 }
+                if let Err(e) = nvs.set_image_url(&creds.url) {
+                    println!("WARNING: failed to write image.url: {:?}", e);
+                }
+                // Any cached BSSID/channel belonging to a prior network is
+                // dropped automatically by the SSID/password setters above;
+                // no separate invalidation step needed.
+                //
+                // Give the HTTP response a moment to flush before we reboot.
+                Timer::after(Duration::from_millis(500)).await;
             }
-            if let Err(e) = nvs.set_image_url(&creds.url) {
-                println!("WARNING: failed to write image.url: {:?}", e);
+            embassy_futures::select::Either::Second(()) => {
+                println!("Refresh pressed — leaving config mode without saving.");
             }
-            // Any cached BSSID/channel belonging to a prior network is
-            // dropped automatically by the SSID/password setters above;
-            // no separate invalidation step needed.
-            //
-            // Give the HTTP response a moment to flush before we reboot.
-            Timer::after(Duration::from_millis(500)).await;
         }
-        embassy_futures::select::Either::Second(()) => {
-            println!("Refresh pressed — leaving config mode without saving.");
-        }
-    }
 
-    println!("Rebooting");
-    esp_hal::system::software_reset();
+        println!("Rebooting");
+        esp_hal::system::software_reset();
+    };
+    embassy_futures::join::join(panel_rendering, wait_and_save)
+        .await
+        .1
 }
 
 #[embassy_executor::task]
@@ -176,13 +182,14 @@ async fn net_task(mut runner: embassy_net::Runner<'static, esp_radio::wifi::Inte
 /// Render the QR + instructions frame for configuration mode and drive
 /// the e-ink refresh, off the hot path so the save / Refresh race in
 /// `run` isn't blocked for ~20 s waiting for the panel to settle.
-#[embassy_executor::task]
-async fn panel_render_task(
+async fn panel_render_task<P>(
     mut spi_bus: Spi<'static, esp_hal::Async>,
-    mut epd: EpdPanel,
+    mut epd: P,
     ap_ssid: String,
-) {
-    let (panel_width, panel_height) = (EpdPanel::WIDTH, EpdPanel::HEIGHT);
+) where
+    P: Panel<Spi<'static, esp_hal::Async>>,
+{
+    let (panel_width, panel_height) = (P::WIDTH, P::HEIGHT);
     // The QR encodes a WiFi-join URI so most phones' camera-app scanners
     // offer a one-tap "Join network" action; the text below it gives the
     // SSID (for manual entry) and the portal URL as a fallback for users
@@ -201,7 +208,7 @@ async fn panel_render_task(
     );
     println!("Rendering config screen with QR: {}", qr_payload);
     let frame =
-        config_image::render::<EpdColor>(panel_width, panel_height, &qr_payload, &instructions);
+        config_image::render::<P::Color>(panel_width, panel_height, &qr_payload, &instructions);
 
     // Bring the panel's enable rail up before any panel I/O.
     // Idempotent — fine if the white pre-flash already raised it.
@@ -214,13 +221,13 @@ async fn panel_render_task(
     // The config-mode frame is rendered with `BLACK` + `WHITE` only
     // (QR plus instruction text); ask the panel which init mode covers
     // that. On E1001 that's `Bw`; single-mode panels return `()`.
-    let init_mode = EpdPanel::init_mode_for_palette([EpdColor::BLACK, EpdColor::WHITE]);
+    let init_mode = P::init_mode_for_palette([P::Color::BLACK, P::Color::WHITE]);
     epd.init(&mut spi_bus, init_mode).await.unwrap();
     println!("Power on");
     epd.power_on(&mut spi_bus).await.unwrap();
     println!("Update frame (QR)");
     let data = (0..(panel_width * panel_height)).map(|idx| {
-        let (x, y) = EpdPanel::output_index_to_image_xy(idx);
+        let (x, y) = P::output_index_to_image_xy(idx);
         frame[y * panel_width + x]
     });
     epd.update_frame(&mut spi_bus, data).await.unwrap();

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -1,61 +1,13 @@
 //! Shared hardware container handed between `main()` and whichever mode
 //! runs this boot (config vs. normal). Keeping it here means neither mode
 //! needs to cfg-gate on the panel model or care about pin counts — they
-//! see the same `EpdPanel` alias and the same field set.
+//! see the same field set.
 
 use embassy_executor::Spawner;
-use esp_hal::gpio::{AnyPin, Output};
+use esp_hal::gpio::AnyPin;
 use esp_hal::spi::master::Spi;
 
 use crate::buzzer::Buzzer;
-use crate::panel::Panel;
-
-#[cfg(feature = "e1002")]
-use crate::panel::gdep073e01::Gdep073e01;
-#[cfg(feature = "e1001")]
-use crate::panel::gdey075t7::Gdey075t7;
-#[cfg(feature = "e1004")]
-use crate::panel::t133a01::T133A01;
-
-/// Fully-specialised type of the built panel driver. All variants
-/// implement the [`crate::panel::Panel`] trait so the rest of the firmware
-/// can drive the panel without caring which model it is.
-#[cfg(feature = "e1001")]
-pub type EpdPanel = Gdey075t7<
-    Spi<'static, esp_hal::Async>,
-    Output<'static>,
-    esp_hal::gpio::Input<'static>,
-    Output<'static>,
-    Output<'static>,
->;
-#[cfg(feature = "e1002")]
-pub type EpdPanel = Gdep073e01<
-    Spi<'static, esp_hal::Async>,
-    Output<'static>,
-    esp_hal::gpio::Input<'static>,
-    Output<'static>,
-    Output<'static>,
->;
-#[cfg(feature = "e1004")]
-pub type EpdPanel = T133A01<
-    Spi<'static, esp_hal::Async>,
-    Output<'static>, // cs_master
-    Output<'static>, // cs_slave
-    esp_hal::gpio::Input<'static>,
-    Output<'static>, // dc
-    Output<'static>, // rst
-    Output<'static>, // en (TFT_EN rail)
->;
-
-/// The panel's pixel colour type. Aliased through the `Panel` trait
-/// projection so callers can write `EpdColor::WHITE` etc. without
-/// hard-coding `Spectra6Color` / `Gray2` per device.
-pub type EpdColor = <EpdPanel as Panel<Spi<'static, esp_hal::Async>>>::Color;
-
-/// The panel's per-init mode selector — see [`Panel::InitMode`]. Most
-/// devices use `()` (single mode); E1001's UC8179 driver exposes
-/// `Bw` / `FourLevel`.
-pub type EpdInitMode = <EpdPanel as Panel<Spi<'static, esp_hal::Async>>>::InitMode;
 
 /// What the user (or the wake timer) wants us to do this cycle. Consumed
 /// by the normal flow to pick an `action=` query-string fragment and to
@@ -96,9 +48,10 @@ impl WakeAction {
 }
 
 /// Everything both `config_mode::run` and `main_normal` need. The panel
-/// driver is pre-built (aliased as `EpdPanel` above) so neither mode needs
-/// cfg gates for pin counts or panel-model-specific types.
-pub struct HardwareCtx {
+/// driver is pre-built by `main`, and the modes stay generic over the
+/// concrete driver so they don't need cfg gates for pin counts or
+/// panel-model-specific types.
+pub struct HardwareCtx<P> {
     pub spawner: Spawner,
     pub rtc: esp_hal::rtc_cntl::Rtc<'static>,
     pub wake_action: WakeAction,
@@ -115,7 +68,7 @@ pub struct HardwareCtx {
     /// driver implements [`crate::panel::Panel`] including `enable` /
     /// `disable` for the board-level TFT rail on devices that have one.
     pub spi_bus: Spi<'static, esp_hal::Async>,
-    pub epd: EpdPanel,
+    pub epd: P,
 
     /// Buzzer driver pre-built around the GPIO45 piezo + LEDC peripheral.
     /// Always populated — both E1002 and E1004 have the piezo on the

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -20,7 +20,7 @@ use crate::battery;
 use crate::button::wait_for_press;
 use crate::config::Config;
 use crate::error_image;
-use crate::hardware::{EpdColor, EpdPanel, HardwareCtx, WakeAction};
+use crate::hardware::{HardwareCtx, WakeAction};
 use crate::panel::{Panel, PanelColor};
 use crate::rtc_persisted::RtcPersisted;
 use crate::sht40;
@@ -171,7 +171,10 @@ impl From<String> for FetchError {
 /// white pre-flash that `main()`'s `run_normal_boot` may have kicked
 /// off, then deep-sleep waking on either the `Refresh:` interval (or
 /// the fallback timer) or a button press.
-pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
+pub async fn run<P>(ctx: HardwareCtx<P>, mut config: Config<'static>) -> !
+where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>>,
+{
     let HardwareCtx {
         rtc,
         wake_action,
@@ -184,7 +187,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
         ..
     } = ctx;
 
-    let (panel_width, panel_height) = (EpdPanel::WIDTH, EpdPanel::HEIGHT);
+    let (panel_width, panel_height) = (P::WIDTH, P::HEIGHT);
 
     // Figure out what to fetch this cycle. Start from whatever's in
     // RTC (defaulting to the NVS URL on cold boot) and adjust per the
@@ -297,7 +300,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
     // error path can still honour it. `try_decode_frame` returns
     // both the row-major frame and the actual PNG palette (sized to
     // `1 << bit_depth`) so the caller can pick a panel init mode.
-    let frame_result: Result<(Vec<EpdColor>, Vec<EpdColor>), String>;
+    let frame_result: Result<(Vec<P::Color>, Vec<P::Color>), String>;
     let hint: Option<RefreshHint>;
     match fetch_result {
         Ok((body, h)) => {
@@ -318,7 +321,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
     // absolute `Instant` so the time we then spend on the panel refresh
     // + UART flush is automatically subtracted from the sleep duration
     // when we compute it below.
-    let (frame, palette, wakeup_requested): (_, Vec<EpdColor>, embassy_time::Instant) =
+    let (frame, palette, wakeup_requested): (_, Vec<P::Color>, embassy_time::Instant) =
         match frame_result {
             Ok((frame, palette)) => {
                 match hint.as_ref().and_then(|h| h.url_override.as_deref()) {
@@ -371,7 +374,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
                 // so its effective palette is exactly those two colours.
                 (
                     error_image::render(panel_width, panel_height, &msg, Some(retry_in)),
-                    Vec::from([EpdColor::BLACK, EpdColor::WHITE]),
+                    Vec::from([P::Color::BLACK, P::Color::WHITE]),
                     wakeup,
                 )
             }
@@ -393,8 +396,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
     // present in the PNG palette (≈ half the SPI traffic + faster
     // waveform when the server-side content is already 1bpp).
     // Single-mode panels return `()` immediately without iterating.
-    let init_mode = EpdPanel::init_mode_for_palette(palette.iter().copied());
-    println!("Init mode: {:?}", init_mode);
+    let init_mode = P::init_mode_for_palette(palette.iter().copied());
     let panel_update = async {
         // Bring the panel's enable rail up before any panel I/O.
         // Idempotent — fine if the white pre-flash already raised it.
@@ -409,7 +411,7 @@ pub async fn run(ctx: HardwareCtx, mut config: Config<'static>) -> ! {
         epd.power_on(&mut spi_bus).await.unwrap();
         println!("Update frame");
         let data = (0..(panel_width * panel_height)).map(|idx| {
-            let (x, y) = EpdPanel::output_index_to_image_xy(idx);
+            let (x, y) = P::output_index_to_image_xy(idx);
             frame[y * panel_width + x]
         });
         epd.update_frame(&mut spi_bus, data).await.unwrap();

--- a/src/panic_mode.rs
+++ b/src/panic_mode.rs
@@ -28,7 +28,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use esp_println::println;
 
 use crate::error_image;
-use crate::hardware::{EpdColor, EpdPanel, HardwareCtx};
+use crate::hardware::HardwareCtx;
 use crate::panel::{Panel, PanelColor};
 use crate::rtc_persisted::RtcPersisted;
 use crate::uart::wait_for_tx_idle;
@@ -196,7 +196,10 @@ fn force_led_on() {
 /// rendered frame also omits the "Will retry in …" line that
 /// transient-error frames carry, since there's nothing scheduled to
 /// retry.
-pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
+pub async fn run<P>(ctx: HardwareCtx<P>, message: &str) -> !
+where
+    P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>>,
+{
     let HardwareCtx {
         rtc,
         mut gpio_btn_refresh,
@@ -210,10 +213,10 @@ pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
     println!("PANIC_MSG present; rendering panic frame");
     println!("Panic: {}", message);
 
-    let panel_width = EpdPanel::WIDTH;
-    let panel_height = EpdPanel::HEIGHT;
-    let frame: Vec<EpdColor> = error_image::render(panel_width, panel_height, message, None);
-    let init_mode = EpdPanel::init_mode_for_palette([EpdColor::BLACK, EpdColor::WHITE]);
+    let panel_width = P::WIDTH;
+    let panel_height = P::HEIGHT;
+    let frame: Vec<P::Color> = error_image::render(panel_width, panel_height, message, None);
+    let init_mode = P::init_mode_for_palette([P::Color::BLACK, P::Color::WHITE]);
 
     // Bring the panel's enable rail up before any panel I/O.
     epd.enable().await.unwrap();
@@ -229,7 +232,7 @@ pub async fn run(ctx: HardwareCtx, message: &str) -> ! {
     epd.update_frame(
         &mut spi_bus,
         (0..(panel_width * panel_height)).map(|idx| {
-            let (x, y) = EpdPanel::output_index_to_image_xy(idx);
+            let (x, y) = P::output_index_to_image_xy(idx);
             frame[y * panel_width + x]
         }),
     )


### PR DESCRIPTION
## Summary
- remove the EpdPanel/EpdColor/EpdInitMode aliases from hardware
- make HardwareCtx and panel-consuming flows generic over the concrete Panel implementation
- run config-mode panel rendering as a generic future joined with the save/refresh exit path

## Testing
- cargo check --features e1001
- cargo check --features e1002
- cargo check --features e1004