### PR TITLE
Move normal-mode setup into normal mode

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -15,9 +15,9 @@ use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
 use esp_hal::gpio::{Level, Output, OutputConfig};
 use esp_println::println;
 
-use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
+use esp_hal::spi::Mode as SpiMode;
 
 use esp_hal::system::SleepSource;
 
@@ -274,14 +274,6 @@ async fn main(spawner: Spawner) -> ! {
          latched[refresh={refresh_latched} previous={previous_latched} next={next_latched}] \
          uptime={time_since_boot:?}"
     );
-    println!(
-        "RTC CURRENT_URL: {:?}",
-        epd_photoframe::normal_mode::CURRENT_URL.get().as_deref()
-    );
-    println!(
-        "RTC REDIRECT_URL: {:?}",
-        epd_photoframe::normal_mode::REDIRECT_URL.get().as_deref()
-    );
 
     // Load runtime configuration from NVS. A fresh / blank partition is
     // not an error (esp-nvs treats all-0xFF as "no entries yet"), so the
@@ -321,20 +313,6 @@ async fn main(spawner: Spawner) -> ! {
 
     spawner.spawn(blink_task(Output::new(led_pin, Level::Low, OutputConfig::default())).unwrap());
 
-    // By the time the URL is being built in `normal_mode::run`, both
-    // sensor signals have been populated — the 10 ms ADC settle + the
-    // 10 ms SHT40 conversion happen alongside the ~1.3 s WiFi association,
-    // so the `wait()`s are essentially free.
-    spawner.spawn(
-        epd_photoframe::normal_mode::sensor_task(
-            Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
-            peripherals.ADC1,
-            peripherals.GPIO1,
-            i2c0,
-        )
-        .unwrap(),
-    );
-
     // Unified hardware context handed off to whichever top-level flow
     // wins (`panic_mode::run`, `run_normal_boot`, then `normal_mode::run`
     // or `config_mode::run`). The panel's board-level enable rail
@@ -347,6 +325,10 @@ async fn main(spawner: Spawner) -> ! {
         rtc,
         wake_action,
         wifi: peripherals.WIFI,
+        battery_enable: Output::new(peripherals.GPIO21, Level::Low, OutputConfig::default()),
+        adc1: peripherals.ADC1,
+        battery_sense: peripherals.GPIO1,
+        i2c0,
         gpio_btn_refresh: gpio_btn_refresh.degrade(),
         gpio_btn_previous: gpio_btn_previous.degrade(),
         gpio_btn_next: gpio_btn_next.degrade(),

--- a/src/hardware.rs
+++ b/src/hardware.rs
@@ -4,7 +4,7 @@
 //! see the same field set.
 
 use embassy_executor::Spawner;
-use esp_hal::gpio::AnyPin;
+use esp_hal::gpio::{AnyPin, Output};
 use esp_hal::spi::master::Spi;
 
 use crate::buzzer::Buzzer;
@@ -56,6 +56,13 @@ pub struct HardwareCtx<P> {
     pub rtc: esp_hal::rtc_cntl::Rtc<'static>,
     pub wake_action: WakeAction,
     pub wifi: esp_hal::peripherals::WIFI<'static>,
+
+    /// Sensor hardware used only by the normal refresh flow to populate
+    /// battery / temperature / humidity / charger status URL parameters.
+    pub battery_enable: Output<'static>,
+    pub adc1: esp_hal::peripherals::ADC1<'static>,
+    pub battery_sense: esp_hal::peripherals::GPIO1<'static>,
+    pub i2c0: esp_hal::i2c::master::I2c<'static, esp_hal::Async>,
 
     /// Button pins; held so the normal flow can hand them to
     /// `RtcioWakeupSource` as deep-sleep wake sources.

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -176,9 +176,14 @@ where
     P: Panel<esp_hal::spi::master::Spi<'static, esp_hal::Async>>,
 {
     let HardwareCtx {
+        spawner,
         rtc,
         wake_action,
         wifi,
+        battery_enable,
+        adc1,
+        battery_sense,
+        i2c0,
         mut gpio_btn_refresh,
         mut gpio_btn_previous,
         mut gpio_btn_next,
@@ -188,6 +193,15 @@ where
     } = ctx;
 
     let (panel_width, panel_height) = (P::WIDTH, P::HEIGHT);
+
+    println!("RTC CURRENT_URL: {:?}", CURRENT_URL.get().as_deref());
+    println!("RTC REDIRECT_URL: {:?}", REDIRECT_URL.get().as_deref());
+
+    // By the time the URL is being built below, both sensor signals
+    // should be populated — the 10 ms ADC settle + the 10 ms SHT40
+    // conversion happen alongside the ~1.3 s WiFi association, so the
+    // `wait()`s in the fetch closure are essentially free.
+    spawner.spawn(sensor_task(battery_enable, adc1, battery_sense, i2c0).unwrap());
 
     // Figure out what to fetch this cycle. Start from whatever's in
     // RTC (defaulting to the NVS URL on cold boot) and adjust per the
@@ -437,7 +451,7 @@ where
             gpio_btn_next.reborrow(),
             InputConfig::default().with_pull(Pull::Up),
         );
-        use embassy_futures::select::{Either4, select4};
+        use embassy_futures::select::{select4, Either4};
         match select4(
             panel_update,
             wait_for_press(&mut refresh_in, BUTTON_DEBOUNCE),


### PR DESCRIPTION
## Summary
- move normal-mode RTC persisted URL debug logging into normal_mode::run
- move normal-mode sensor task startup into normal_mode::run
- pass the sensor hardware through HardwareCtx so main only constructs hardware and normal mode owns normal-only setup

## Reasoning
This keeps main focused on generic initialization and board-specific hardware construction. The RTC URL diagnostics and sensor task are only meaningful for the normal refresh flow, so normal_mode::run is the narrower owner. The sensor task still starts before URL construction and overlaps with WiFi association, which should keep the later sensor waits effectively free.

## Testing
- rustfmt --edition 2021 --check src/bin/main.rs src/hardware.rs src/normal_mode.rs
- cargo check --features e1001
- cargo check --features e1002
- cargo check --features e1004,disable_charger