### PR TITLE
Enforce rustfmt and clippy in pre-commit

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+set -eu
+
+echo "Checking Rust formatting..."
+cargo fmt --check
+
+echo "Checking clippy for e1001..."
+cargo clippy --features e1001 -- -D warnings
+
+echo "Checking clippy for e1002..."
+cargo clippy --features e1002 -- -D warnings
+
+echo "Checking clippy for e1004 + disable_charger..."
+cargo clippy --features e1004,disable_charger -- -D warnings

--- a/src/battery.rs
+++ b/src/battery.rs
@@ -76,11 +76,11 @@ pub async fn read_battery(
     let mut adc = Adc::new(adc_peripheral, adc_config);
 
     let mut samples = [0u16; SAMPLE_COUNT];
-    for i in 0..SAMPLE_COUNT {
+    for (i, sample) in samples.iter_mut().enumerate() {
         if i > 0 {
             Timer::after(SAMPLE_INTERVAL).await;
         }
-        samples[i] = adc.read_blocking(&mut adc_pin);
+        *sample = adc.read_blocking(&mut adc_pin);
     }
     enable_pin.set_low();
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -12,13 +12,13 @@ use esp_hal::clock::CpuClock;
 use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
 use esp_hal::gpio::{Level, Output, OutputConfig};
 
+use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
-use esp_hal::spi::Mode as SpiMode;
 
 extern crate alloc;
 
-use epd_photoframe::app::{init_runtime, run_app, AppHardware};
+use epd_photoframe::app::{AppHardware, init_runtime, run_app};
 
 #[cfg(feature = "e1002")]
 use epd_photoframe::panel::gdep073e01::Gdep073e01;

--- a/src/config_mode.rs
+++ b/src/config_mode.rs
@@ -146,10 +146,10 @@ where
                 if let Err(e) = nvs.set_wifi_ssid(&creds.ssid) {
                     println!("WARNING: failed to write wifi.ssid: {:?}", e);
                 }
-                if let Some(pw) = creds.password.as_deref() {
-                    if let Err(e) = nvs.set_wifi_password(pw) {
-                        println!("WARNING: failed to write wifi.pass: {:?}", e);
-                    }
+                if let Some(pw) = creds.password.as_deref()
+                    && let Err(e) = nvs.set_wifi_password(pw)
+                {
+                    println!("WARNING: failed to write wifi.pass: {:?}", e);
                 }
                 if let Err(e) = nvs.set_image_url(&creds.url) {
                     println!("WARNING: failed to write image.url: {:?}", e);

--- a/src/iter_util.rs
+++ b/src/iter_util.rs
@@ -26,10 +26,10 @@ impl<I: Iterator, const N: usize> Iterator for ChunksHeapless<I, N> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let mut ret = heapless::Vec::new();
-        if let Some(stored) = self.stored.take() {
-            if let Err(stored) = ret.push(stored) {
-                self.stored = Some(stored);
-            }
+        if let Some(stored) = self.stored.take()
+            && let Err(stored) = ret.push(stored)
+        {
+            self.stored = Some(stored);
         }
         while self.stored.is_none()
             && let Some(next) = self.inner.next()

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -83,6 +83,11 @@ pub static POWER_STATUS: embassy_sync::signal::Signal<
     Option<sy6974b::PowerStatus>,
 > = embassy_sync::signal::Signal::new();
 
+struct FrameWithPalette<C> {
+    frame: Vec<C>,
+    palette: Vec<C>,
+}
+
 /// Sensor task. Spawned at boot, signals into the [`BATTERY_MV`] /
 /// [`TEMP_HUMIDITY`] / [`POWER_STATUS`] slots. Battery (ADC + GPIO21)
 /// is independent of I²C0, so it runs in parallel with the I²C-bound
@@ -314,7 +319,7 @@ where
     // error path can still honour it. `try_decode_frame` returns
     // both the row-major frame and the actual PNG palette (sized to
     // `1 << bit_depth`) so the caller can pick a panel init mode.
-    let frame_result: Result<(Vec<P::Color>, Vec<P::Color>), String>;
+    let frame_result: Result<FrameWithPalette<P::Color>, String>;
     let hint: Option<RefreshHint>;
     match fetch_result {
         Ok((body, h)) => {
@@ -335,14 +340,14 @@ where
     // absolute `Instant` so the time we then spend on the panel refresh
     // + UART flush is automatically subtracted from the sleep duration
     // when we compute it below.
-    let (frame, palette, wakeup_requested): (_, Vec<P::Color>, embassy_time::Instant) =
+    let (frame, wakeup_requested): (FrameWithPalette<P::Color>, embassy_time::Instant) =
         match frame_result {
-            Ok((frame, palette)) => {
-                match hint.as_ref().and_then(|h| h.url_override.as_deref()) {
+            Ok(frame) => {
+                if let Some(raw) = hint.as_ref().and_then(|h| h.url_override.as_deref()) {
                     // The server often sends relative URLs (e.g. just
                     // `/screen/foo`), so resolve against whatever we just
                     // fetched rather than the NVS base.
-                    Some(raw) => match url_util::resolve(&current_url, raw) {
+                    match url_util::resolve(&current_url, raw) {
                         Some(abs) => {
                             match heapless::String::<STORED_URL_MAX>::try_from(abs.as_str()) {
                                 Ok(stored) => {
@@ -362,16 +367,12 @@ where
                             println!("Unresolvable redirect URL {:?}; dropping", raw);
                             REDIRECT_URL.clear();
                         }
-                    },
-                    // No pending redirect from the server — leave the slot
-                    // empty (already cleared on entry for non-Timer wakes;
-                    // `take()`n on entry for Timer wakes).
-                    None => {}
+                    }
                 }
                 let wakeup = hint
                     .map(|h| h.refresh_time)
                     .unwrap_or_else(|| embassy_time::Instant::now() + DEFAULT_SUCCESS_SLEEP);
-                (frame, palette, wakeup)
+                (frame, wakeup)
             }
             Err(msg) => {
                 println!("Falling back to error image: {}", msg);
@@ -387,12 +388,15 @@ where
                 // The error image is rendered with `BLACK` and `WHITE` only,
                 // so its effective palette is exactly those two colours.
                 (
-                    error_image::render(panel_width, panel_height, &msg, Some(retry_in)),
-                    Vec::from([P::Color::BLACK, P::Color::WHITE]),
+                    FrameWithPalette {
+                        frame: error_image::render(panel_width, panel_height, &msg, Some(retry_in)),
+                        palette: Vec::from([P::Color::BLACK, P::Color::WHITE]),
+                    },
                     wakeup,
                 )
             }
         };
+    let FrameWithPalette { frame, palette } = frame;
 
     // --- Real refresh: reset aborts the (possibly still running) white refresh. ---
     //
@@ -451,7 +455,7 @@ where
             gpio_btn_next.reborrow(),
             InputConfig::default().with_pull(Pull::Up),
         );
-        use embassy_futures::select::{select4, Either4};
+        use embassy_futures::select::{Either4, select4};
         match select4(
             panel_update,
             wait_for_press(&mut refresh_in, BUTTON_DEBOUNCE),
@@ -562,9 +566,12 @@ async fn try_fetch<'t>(
             .query(&host, embassy_net::dns::DnsQueryType::A)
             .await
             .map_err(|e| format!("DNS {}: {:?}", host, e))?;
-        let v4 = addrs.iter().find_map(|a| match a {
-            embassy_net::IpAddress::Ipv4(v) => Some(*v),
-        });
+        let v4 = addrs
+            .iter()
+            .map(|a| match a {
+                embassy_net::IpAddress::Ipv4(v) => *v,
+            })
+            .next();
         v4.ok_or_else(|| format!("DNS: no A record for {}", host))?
     };
     let addr = SocketAddr::new(IpAddr::V4(ip), port);
@@ -707,15 +714,16 @@ async fn try_fetch<'t>(
 /// are by far the biggest transient allocations in the fetch cycle, and
 /// we run with WiFi off while they're in flight.
 ///
-/// Returns `(frame, palette)`. The palette holds exactly the
-/// `1 << bit_depth` real PNG palette entries (2 for 1bpp, 4 for 2bpp,
-/// …) — the caller passes it to [`Panel::init_mode_for_palette`] to
-/// pick the cheapest panel init mode that covers the content.
+/// Returns a [`FrameWithPalette`] containing the row-major frame and PNG
+/// palette. The palette holds exactly the `1 << bit_depth` real PNG
+/// palette entries (2 for 1bpp, 4 for 2bpp, …) — the caller passes it
+/// to [`Panel::init_mode_for_palette`] to pick the cheapest panel init
+/// mode that covers the content.
 fn try_decode_frame<C: PanelColor>(
     body: &[u8],
     panel_width: usize,
     panel_height: usize,
-) -> Result<(Vec<C>, Vec<C>), String> {
+) -> Result<FrameWithPalette<C>, String> {
     use embedded_graphics::pixelcolor::Rgb888;
     println!("Decode PNG");
     let header = minipng::decode_png_header(body).map_err(|e| format!("PNG header: {:?}", e))?;
@@ -809,7 +817,10 @@ fn try_decode_frame<C: PanelColor>(
             frame.push(png_palette[palette_index as usize]);
         }
     }
-    Ok((frame, png_palette))
+    Ok(FrameWithPalette {
+        frame,
+        palette: png_palette,
+    })
 }
 
 /// Extract the palette index for pixel `x` in a row packed at `bit_depth`

--- a/src/panel/gdep073e01.rs
+++ b/src/panel/gdep073e01.rs
@@ -10,7 +10,7 @@ use embedded_hal_async::spi::SpiBus;
 // Panel: GooDisplay GDEP073E01 (800x480, Spectra 6, found in reTerminal E1002).
 // Controller appears similar to UC8159 / SPD1656.
 
-#[allow(non_camel_case_types, dead_code)]
+#[allow(non_camel_case_types, dead_code, clippy::upper_case_acronyms)]
 #[derive(Copy, Clone)]
 enum Command {
     PanelSetting = 0x00,

--- a/src/panel/t133a01.rs
+++ b/src/panel/t133a01.rs
@@ -11,7 +11,7 @@ const SINGLE_BYTE_WRITE: bool = false;
 const PANEL_WIDTH: usize = 1200;
 const PANEL_HEIGHT: usize = 1600;
 
-#[allow(non_camel_case_types, dead_code)]
+#[allow(non_camel_case_types, dead_code, clippy::upper_case_acronyms)]
 #[derive(Copy, Clone)]
 enum Command {
     PanelSetting = 0x00, // PSR
@@ -112,8 +112,7 @@ pub struct T133A01<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En> {
     en: En,
 }
 
-impl<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En>
-    T133A01<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En>
+impl<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En> T133A01<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En>
 where
     CsMaster: OutputPin,
     CsSlave: OutputPin,
@@ -145,8 +144,7 @@ where
     }
 }
 
-impl<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En>
-    T133A01<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En>
+impl<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En> T133A01<Spi, CsMaster, CsSlave, Busy, Dc, Rst, En>
 where
     Spi: SpiBus,
     CsMaster: OutputPin,

--- a/src/single_shot_wifi.rs
+++ b/src/single_shot_wifi.rs
@@ -105,8 +105,8 @@ impl Error {
             Error::Init(e) => format!("WiFi init failed: {:?}", e),
             Error::Connect(e) => format!("WiFi connect failed: {:?}\nSSID: {}", e, ssid),
             Error::Timeout => format!("WiFi setup timed out\nSSID: {}", ssid),
-            Error::CredentialsError => format!("WiFi credentials read failed"),
-            Error::EmptyCredentials => format!("WiFi credentials missing"),
+            Error::CredentialsError => String::from("WiFi credentials read failed"),
+            Error::EmptyCredentials => String::from("WiFi credentials missing"),
         }
     }
 }
@@ -228,10 +228,7 @@ where
                 .clone()
                 .with_bssid(h.bssid)
                 .with_channel(h.channel);
-            (
-                pinned,
-                Some(esp_radio::wifi::Config::Station(base_sta_cfg)),
-            )
+            (pinned, Some(esp_radio::wifi::Config::Station(base_sta_cfg)))
         }
         None => {
             println!("WiFi hint: none (cold boot or stale; will scan)");
@@ -362,8 +359,12 @@ async fn wifi_runner<'d, S: WifiCredStore + ?Sized>(
                     Ok(info) => {
                         println!(
                             "Connected to BSSID {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x} on channel {}",
-                            info.bssid[0], info.bssid[1], info.bssid[2],
-                            info.bssid[3], info.bssid[4], info.bssid[5],
+                            info.bssid[0],
+                            info.bssid[1],
+                            info.bssid[2],
+                            info.bssid[3],
+                            info.bssid[4],
+                            info.bssid[5],
                             info.channel
                         );
                         // We're already associated; a hint-write


### PR DESCRIPTION
## Summary
- run cargo fmt across the repo and commit the resulting formatting changes
- fix current clippy warnings so all supported feature sets pass with -D warnings
- add a repo-local .githooks/pre-commit hook that checks rustfmt and clippy for e1001, e1002, and e1004 + disable_charger

## Notes
- This checkout has core.hooksPath set to .githooks so the hook is active locally.
- Clippy acronym warnings on panel command enums are allowed intentionally because those names mirror controller/datasheet command names.

## Testing
- .githooks/pre-commit
- cargo fmt --check
- cargo clippy --features e1001 -- -D warnings
- cargo clippy --features e1002 -- -D warnings
- cargo clippy --features e1004,disable_charger -- -D warnings