### PR TITLE
Lift device app configuration into main

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -62,6 +62,8 @@ pub struct AppHardware<P> {
     pub gpio_btn_previous: AnyPin<'static>,
     pub gpio_btn_next: AnyPin<'static>,
     pub led_pin: AnyPin<'static>,
+    pub refresh_button_label: &'static str,
+    pub has_sy6974b: bool,
     pub spi_bus: Spi<'static, esp_hal::Async>,
     pub epd: P,
     pub i2c0: esp_hal::i2c::master::I2c<'static, esp_hal::Async>,
@@ -84,6 +86,8 @@ pub struct AppContext<P> {
     pub rtc: esp_hal::rtc_cntl::Rtc<'static>,
     pub wake_action: WakeAction,
     pub wifi: esp_hal::peripherals::WIFI<'static>,
+    pub refresh_button_label: &'static str,
+    pub has_sy6974b: bool,
 
     /// Sensor hardware used only by the normal refresh flow to populate
     /// battery / temperature / humidity / charger status URL parameters.
@@ -137,14 +141,13 @@ pub async fn run_app<P>(spawner: Spawner, board: AppHardware<P>) -> !
 where
     P: Panel<Spi<'static, esp_hal::Async>>,
 {
-    let reset_reason = esp_hal::rtc_cntl::reset_reason(esp_hal::system::Cpu::ProCpu);
-    let wake_reason = esp_hal::rtc_cntl::wakeup_cause();
-
     let AppHardware {
         gpio_btn_refresh,
         gpio_btn_previous,
         gpio_btn_next,
         led_pin,
+        refresh_button_label,
+        has_sy6974b,
         spi_bus,
         epd,
         i2c0,
@@ -157,6 +160,11 @@ where
         ledc,
         buzzer_pin,
     } = board;
+
+    panic_mode::set_panic_led(led_pin.number());
+
+    let reset_reason = esp_hal::rtc_cntl::reset_reason(esp_hal::system::Cpu::ProCpu);
+    let wake_reason = esp_hal::rtc_cntl::wakeup_cause();
 
     // Snapshot the RTC-IO wake latch (which pin actually triggered the wake)
     // and clear it immediately so stale bits don't carry into the next cycle.
@@ -237,6 +245,8 @@ where
         rtc,
         wake_action,
         wifi,
+        refresh_button_label,
+        has_sy6974b,
         battery_enable: Output::new(battery_enable_pin, Level::Low, OutputConfig::default()),
         adc1,
         battery_sense,

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -61,6 +61,14 @@ async fn main(spawner: Spawner) -> ! {
         peripherals.GPIO48,
     );
 
+    #[cfg(any(feature = "e1001", feature = "e1002"))]
+    // E1001 / E1002 appear to have an SY6974B on I2C1, but it is not
+    // accessible from this firmware setup, so normal-mode power status
+    // reporting is disabled for them.
+    let (refresh_button_label, has_sy6974b) = ("Refresh button (green)", false);
+    #[cfg(feature = "e1004")]
+    let (refresh_button_label, has_sy6974b) = ("Refresh button", true);
+
     // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
     let epd_spi_bus = Spi::new(
         peripherals.SPI2,
@@ -146,6 +154,8 @@ async fn main(spawner: Spawner) -> ! {
         gpio_btn_previous: gpio_btn_previous.degrade(),
         gpio_btn_next: gpio_btn_next.degrade(),
         led_pin: led_pin.degrade(),
+        refresh_button_label,
+        has_sy6974b,
         spi_bus: epd_spi_bus,
         epd,
         i2c0,

--- a/src/config_mode.rs
+++ b/src/config_mode.rs
@@ -32,6 +32,7 @@ where
         spawner,
         wifi,
         gpio_btn_refresh,
+        refresh_button_label,
         spi_bus,
         epd,
         mut buzzer,
@@ -104,13 +105,22 @@ where
     spawner.spawn(net_task(net_runner).unwrap());
     spawner.spawn(dhcp_server_task(net_stack).unwrap());
     spawner.spawn(dns_hijack_task(net_stack).unwrap());
-    spawner.spawn(portal::web_task(net_stack, stored_ssid, stored_url, password_is_set).unwrap());
+    spawner.spawn(
+        portal::web_task(
+            net_stack,
+            stored_ssid,
+            stored_url,
+            password_is_set,
+            refresh_button_label,
+        )
+        .unwrap(),
+    );
 
     // Run panel rendering alongside the save / Refresh race. If panel
     // rendering finishes first, config mode keeps serving the portal; if
     // the user exits first, software reset interrupts the render and the
     // next boot's own panel reset recovers.
-    let panel_rendering = panel_render_task(spi_bus, epd, ap_ssid);
+    let panel_rendering = panel_render_task(spi_bus, epd, ap_ssid, refresh_button_label);
 
     let wait_and_save = async {
         // Two exits from config mode:
@@ -186,6 +196,7 @@ async fn panel_render_task<P>(
     mut spi_bus: Spi<'static, esp_hal::Async>,
     mut epd: P,
     ap_ssid: String,
+    refresh_button_label: &'static str,
 ) where
     P: Panel<Spi<'static, esp_hal::Async>>,
 {
@@ -203,8 +214,7 @@ async fn panel_render_task<P>(
          Then open: http://192.168.4.1/\n\
          \n\
          Press the {} to exit without saving.",
-        ap_ssid,
-        portal::REFRESH_BUTTON_LABEL
+        ap_ssid, refresh_button_label
     );
     println!("Rendering config screen with QR: {}", qr_payload);
     let frame =

--- a/src/config_mode/portal.rs
+++ b/src/config_mode/portal.rs
@@ -28,16 +28,6 @@ use esp_println::println;
 /// *not* the sentinel is therefore a malformed submission.
 pub const PASSWORD_SENTINEL: &str = "___________________________unchanged___________________________unchanged___________________________";
 
-/// Device-specific label for the Refresh button — on the E1001 / E1002
-/// it's the unmarked green button, so we spell that out in the
-/// instructions; on the E1004 the button is clearly iconed and needs
-/// no qualifier. Used both in the portal HTML and in the panel
-/// instructions rendered by `config_mode`.
-#[cfg(any(feature = "e1001", feature = "e1002"))]
-pub const REFRESH_BUTTON_LABEL: &str = "Refresh button (green)";
-#[cfg(feature = "e1004")]
-pub const REFRESH_BUTTON_LABEL: &str = "Refresh button";
-
 const FORM_TEMPLATE: &str = include_str!("form.html");
 const SAVED_HTML: &[u8] = include_bytes!("saved.html");
 
@@ -98,7 +88,13 @@ pub static SAVE_SIGNAL: Signal<CriticalSectionRawMutex, PortalCreds> = Signal::n
 /// The password field is echoed back verbatim (modulo escaping) — the
 /// user and the browser already saw it when it was typed, so echoing
 /// it on a re-render leaks nothing and spares them a retype.
-fn render_form(ssid: &str, password: &str, url: &str, error: Option<&str>) -> String {
+fn render_form(
+    ssid: &str,
+    password: &str,
+    url: &str,
+    error: Option<&str>,
+    refresh_button_label: &str,
+) -> String {
     let error_html = match error {
         Some(msg) => alloc::format!(r#"<p class="error">{}</p>"#, html_attr_escape(msg)),
         None => String::new(),
@@ -108,7 +104,7 @@ fn render_form(ssid: &str, password: &str, url: &str, error: Option<&str>) -> St
         .replace("{ssid}", &html_attr_escape(ssid))
         .replace("{password}", &html_attr_escape(password))
         .replace("{url}", &html_attr_escape(url))
-        .replace("{refresh_hint}", REFRESH_BUTTON_LABEL)
+        .replace("{refresh_hint}", refresh_button_label)
 }
 
 /// Minimal HTML escape for values going into a double-quoted attribute.
@@ -136,6 +132,7 @@ pub struct PortalHandler {
     default_ssid: String,
     default_url: String,
     default_password_is_set: bool,
+    refresh_button_label: &'static str,
 }
 
 impl Handler for PortalHandler {
@@ -162,7 +159,7 @@ impl Handler for PortalHandler {
         if method == Method::Post {
             let path_is_save = conn.headers()?.path == "/save";
             if path_is_save {
-                return handle_save(conn, content_len).await;
+                return handle_save(conn, content_len, self.refresh_button_label).await;
             }
         }
         // Everything else (including all captive-portal probes) returns
@@ -180,6 +177,7 @@ impl Handler for PortalHandler {
             default_password,
             &self.default_url,
             None,
+            self.refresh_button_label,
         );
         write_form(conn, &html, 200, "OK").await
     }
@@ -188,6 +186,7 @@ impl Handler for PortalHandler {
 async fn handle_save<T, const N: usize>(
     conn: &mut Connection<'_, T, N>,
     content_len: usize,
+    refresh_button_label: &str,
 ) -> Result<(), Error<T::Error>>
 where
     T: Read + Write + edge_nal::TcpSplit,
@@ -210,7 +209,13 @@ where
         Some(r) => r,
         None => {
             println!("portal: form body did not parse");
-            let html = render_form("", "", "", Some(FormError::Unparseable.message()));
+            let html = render_form(
+                "",
+                "",
+                "",
+                Some(FormError::Unparseable.message()),
+                refresh_button_label,
+            );
             return write_form(conn, &html, 400, "Bad Request").await;
         }
     };
@@ -241,7 +246,13 @@ where
         }
         Err(err) => {
             println!("portal: validation failed: {}", err.message());
-            let html = render_form(&raw.ssid, &raw.password, &raw.url, Some(err.message()));
+            let html = render_form(
+                &raw.ssid,
+                &raw.password,
+                &raw.url,
+                Some(err.message()),
+                refresh_button_label,
+            );
             write_form(conn, &html, 400, "Bad Request").await
         }
     }
@@ -361,7 +372,13 @@ fn url_decode(s: &str) -> String {
 /// concurrent handler tasks cover phones that pipeline captive-portal
 /// probes without burning too much RAM on buffers.
 #[embassy_executor::task]
-pub async fn web_task(stack: Stack<'static>, ssid: String, url: String, password_is_set: bool) {
+pub async fn web_task(
+    stack: Stack<'static>,
+    ssid: String,
+    url: String,
+    password_is_set: bool,
+    refresh_button_label: &'static str,
+) {
     use core::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     use edge_nal::TcpBind;
@@ -379,6 +396,7 @@ pub async fn web_task(stack: Stack<'static>, ssid: String, url: String, password
         default_ssid: ssid,
         default_url: url,
         default_password_is_set: password_is_set,
+        refresh_button_label,
     };
     println!("HTTP portal listening on :80");
     loop {

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -92,20 +92,23 @@ struct FrameWithPalette<C> {
 /// [`TEMP_HUMIDITY`] / [`POWER_STATUS`] slots. Battery (ADC + GPIO21)
 /// is independent of I²C0, so it runs in parallel with the I²C-bound
 /// chain. Inside the chain, reads share the bus sequentially: SHT40
-/// first, then (E1004 only) the SY6974B charger.
+/// first, then the SY6974B charger on boards where that chip is
+/// accessible to this firmware.
 #[embassy_executor::task]
 pub async fn sensor_task(
     battery_enable: Output<'static>,
     adc1: esp_hal::peripherals::ADC1<'static>,
     battery_sense: esp_hal::peripherals::GPIO1<'static>,
     mut i2c0: esp_hal::i2c::master::I2c<'static, esp_hal::Async>,
+    has_sy6974b: bool,
 ) {
     let i2c_reads = async {
         let temp_humidity = sht40::read_temp_humidity(&mut i2c0).await;
-        #[cfg(feature = "e1004")]
-        let power_status = sy6974b::read_power_status(&mut i2c0).await;
-        #[cfg(not(feature = "e1004"))]
-        let power_status: Option<sy6974b::PowerStatus> = None;
+        let power_status = if has_sy6974b {
+            sy6974b::read_power_status(&mut i2c0).await
+        } else {
+            None
+        };
         (temp_humidity, power_status)
     };
     let (battery_mv, (temp_humidity, power_status)) = embassy_futures::join::join(
@@ -185,6 +188,7 @@ where
         rtc,
         wake_action,
         wifi,
+        has_sy6974b,
         battery_enable,
         adc1,
         battery_sense,
@@ -206,7 +210,7 @@ where
     // should be populated — the 10 ms ADC settle + the 10 ms SHT40
     // conversion happen alongside the ~1.3 s WiFi association, so the
     // `wait()`s in the fetch closure are essentially free.
-    spawner.spawn(sensor_task(battery_enable, adc1, battery_sense, i2c0).unwrap());
+    spawner.spawn(sensor_task(battery_enable, adc1, battery_sense, i2c0, has_sy6974b).unwrap());
 
     // Figure out what to fetch this cycle. Start from whatever's in
     // RTC (defaulting to the NVS URL on cold boot) and adjust per the

--- a/src/panic_mode.rs
+++ b/src/panic_mode.rs
@@ -23,7 +23,7 @@
 
 use alloc::vec::Vec;
 use core::fmt::Write;
-use core::sync::atomic::{AtomicBool, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU8, Ordering};
 
 use esp_println::println;
 
@@ -54,12 +54,21 @@ static PANIC_MSG: RtcPersisted<heapless::String<PANIC_MSG_MAX>> = RtcPersisted::
 /// — the first re-panic halts, the user still sees the previous panic
 /// message on the panel, and JTAG can attach to investigate.
 static REBOOT_ALLOWED: AtomicBool = AtomicBool::new(false);
+const PANIC_LED_UNSET: u8 = u8::MAX;
+static PANIC_LED_GPIO: AtomicU8 = AtomicU8::new(PANIC_LED_UNSET);
 
 /// Allow the panic handler to soft-reset on the next panic. Called by
 /// `main()` once it has confirmed the current cycle is not rendering a
 /// previous panic.
 pub fn allow_reboot() {
     REBOOT_ALLOWED.store(true, Ordering::Relaxed);
+}
+
+/// Set the GPIO number that the panic handler should force high when
+/// halting. Stores only the pin number because the panic handler cannot
+/// rely on owning HAL GPIO objects or on the executor still running.
+pub fn set_panic_led(gpio: u8) {
+    PANIC_LED_GPIO.store(gpio, Ordering::Relaxed);
 }
 
 /// Return any captured panic message from a previous boot, clearing
@@ -159,23 +168,24 @@ fn panic(info: &core::panic::PanicInfo) -> ! {
 /// is what actually enables it; the IO_MUX MCU function defaults to
 /// "GPIO" on these pins, so we don't need to touch IO_MUX.
 fn force_led_on() {
-    let gpio = esp_hal::peripherals::GPIO::regs();
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
-    {
-        // Status LED on GPIO6 — bit 6 of the lower bank.
-        const BIT: u32 = 1 << 6;
-        unsafe {
-            gpio.enable_w1ts().write(|w| w.bits(BIT));
-            gpio.out_w1ts().write(|w| w.bits(BIT));
-        }
+    let gpio_number = PANIC_LED_GPIO.load(Ordering::Relaxed);
+    if gpio_number == PANIC_LED_UNSET {
+        return;
     }
-    #[cfg(feature = "e1004")]
-    {
-        // Status LED on GPIO48 — bit 16 of the upper bank (48 - 32).
-        const BIT: u32 = 1 << (48 - 32);
+
+    let gpio = esp_hal::peripherals::GPIO::regs();
+
+    if gpio_number < 32 {
+        let bit = 1u32 << gpio_number;
         unsafe {
-            gpio.enable1_w1ts().write(|w| w.bits(BIT));
-            gpio.out1_w1ts().write(|w| w.bits(BIT));
+            gpio.enable_w1ts().write(|w| w.bits(bit));
+            gpio.out_w1ts().write(|w| w.bits(bit));
+        }
+    } else if gpio_number < 64 {
+        let bit = 1u32 << (gpio_number - 32);
+        unsafe {
+            gpio.enable1_w1ts().write(|w| w.bits(bit));
+            gpio.out1_w1ts().write(|w| w.bits(bit));
         }
     }
 }


### PR DESCRIPTION
## Summary
- pass board-specific refresh button label and SY6974B availability from main through AppHardware/AppContext
- replace normal-mode charger feature gates with a has_sy6974b runtime capability
- replace panic-mode LED feature gates with a panic-safe GPIO number registered at run_app startup

## Reasoning
This keeps device-specific choices in main while leaving config, normal, and panic modes generic. E1001/E1002 keep power status disabled even though they appear to have an SY6974B on I2C1, because it is not accessible from this firmware setup.

## Remaining device feature gates
- src/bin/main.rs for board-specific pin/panel/SPI construction and disable_charger
- src/lib.rs for feature sanity checks until separate binaries replace device features

## Testing
- .githooks/pre-commit
- cargo check --features e1001
- cargo check --features e1002
- cargo check --features e1004,disable_charger