### PR TITLE
Split firmware into device binaries

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,11 +4,8 @@ set -eu
 echo "Checking Rust formatting..."
 cargo fmt --check
 
-echo "Checking clippy for e1001..."
-cargo clippy --features e1001 -- -D warnings
-
-echo "Checking clippy for e1002..."
-cargo clippy --features e1002 -- -D warnings
+echo "Checking clippy for all binaries..."
+cargo clippy --bins -- -D warnings
 
 echo "Checking clippy for e1004 + disable_charger..."
-cargo clippy --features e1004,disable_charger -- -D warnings
+cargo clippy --bin e1004 --features disable_charger -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,16 +4,7 @@ name         = "epd-photoframe"
 rust-version = "1.91"
 version      = "0.1.0"
 
-[[bin]]
-name = "epd_photoframe"
-path = "./src/bin/main.rs"
-
 [features]
-# Select exactly one device. Each device selects its panel driver and pinout.
-e1001 = [] # Seeed reTerminal E1001 (7", GDEY075T7 panel, 800x480 4-level grayscale)
-e1002 = [] # Seeed reTerminal E1002 (7", GDEP073E01 panel, 800x480)
-e1004 = [] # Seeed reTerminal E1004 (13", T133A01 panel, 1200x1600)
-
 # PPK2 bench-measurement mode (E1004 only). On boot, parks the SY6974B
 # charger in HIZ so the system rail runs entirely from the BAT input,
 # regardless of USB-C state. Intended for a Nordic Power Profiler Kit II

--- a/README.md
+++ b/README.md
@@ -26,10 +26,9 @@ Stretch goals:
 
 Supported devices
 -----------------
-Build with `cargo build --features <device>` (exactly one device feature
-must be enabled — there is no default):
+Build with `cargo build --bin <device>`:
 
-| Feature | Device      | Panel     | Resolution  | State       |
+| Binary  | Device      | Panel     | Resolution  | State       |
 |---------|-------------|-----------|-------------|-------------|
 | `e1001` | reTerminal E1001 (7")  | GDEY075T7  | 800×480 (4-level grayscale) | working    |
 | `e1002` | reTerminal E1002 (7")  | GDEP073E01 | 800×480  | working     |

--- a/run.sh
+++ b/run.sh
@@ -60,11 +60,11 @@ release_flag=""
 if [[ "${RELEASE:-}" == "1" ]]; then
     release_flag="--release"
 fi
-# `EXTRA_FEATURES=foo,bar` env var appends extra cargo features
-# alongside the device feature — e.g. `disable_charger` for PPK2 bench builds.
-features="$device"
+# `EXTRA_FEATURES=foo,bar` env var passes extra cargo features — e.g.
+# `disable_charger` for PPK2 bench builds.
+features=""
 if [[ -n "${EXTRA_FEATURES:-}" ]]; then
-    features="${features},${EXTRA_FEATURES}"
+    features="--features ${EXTRA_FEATURES}"
 fi
 echo $$ > "$pid_file"
-exec script -qfc "cargo run $release_flag --features $features -- --port $port" "$log"
+exec script -qfc "cargo run $release_flag --bin $device $features -- --port $port" "$log"

--- a/src/bin/e1001.rs
+++ b/src/bin/e1001.rs
@@ -1,0 +1,107 @@
+#![no_std]
+#![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
+
+use embassy_executor::Spawner;
+use esp_hal::clock::CpuClock;
+
+use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
+use esp_hal::gpio::{Level, Output, OutputConfig};
+
+use esp_hal::spi::Mode as SpiMode;
+use esp_hal::spi::master::Config as SpiConfig;
+use esp_hal::spi::master::Spi;
+
+extern crate alloc;
+
+use epd_photoframe::app::{AppHardware, init_runtime, run_app};
+use epd_photoframe::panel::gdey075t7::Gdey075t7;
+
+// This creates a default app-descriptor required by the esp-idf bootloader.
+// For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) -> ! {
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    let peripherals = esp_hal::init(config);
+
+    init_runtime(
+        peripherals.PSRAM,
+        peripherals.TIMG0,
+        peripherals.SW_INTERRUPT,
+    );
+
+    let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next, led_pin) = (
+        peripherals.GPIO3,
+        peripherals.GPIO5,
+        peripherals.GPIO4,
+        peripherals.GPIO6,
+    );
+
+    // E1001 / E1002 appear to have an SY6974B on I2C1, but it is not
+    // accessible from this firmware setup, so normal-mode power status
+    // reporting is disabled for them.
+    let (refresh_button_label, has_sy6974b) = ("Refresh button (green)", false);
+
+    // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
+    let epd_spi_bus = Spi::new(
+        peripherals.SPI2,
+        SpiConfig::default()
+            .with_write_bit_order(esp_hal::spi::BitOrder::MsbFirst)
+            .with_frequency(esp_hal::time::Rate::from_mhz(20))
+            .with_mode(SpiMode::_0),
+    )
+    .unwrap();
+
+    let mut epd_spi_bus = epd_spi_bus
+        .with_sck(peripherals.GPIO7)
+        .with_mosi(peripherals.GPIO9)
+        .into_async();
+
+    let epd = Gdey075t7::new(
+        &mut epd_spi_bus,
+        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
+        Input::new(
+            peripherals.GPIO13,
+            InputConfig::default().with_pull(Pull::Up),
+        ),
+        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
+        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
+    );
+
+    // One task later drives both per-wake sensor reads (battery ADC +
+    // SHT40 over I²C0) concurrently via `join`.
+    let i2c0 =
+        esp_hal::i2c::master::I2c::new(peripherals.I2C0, esp_hal::i2c::master::Config::default())
+            .unwrap()
+            .with_sda(peripherals.GPIO19)
+            .with_scl(peripherals.GPIO20)
+            .into_async();
+
+    let board = AppHardware {
+        gpio_btn_refresh: gpio_btn_refresh.degrade(),
+        gpio_btn_previous: gpio_btn_previous.degrade(),
+        gpio_btn_next: gpio_btn_next.degrade(),
+        led_pin: led_pin.degrade(),
+        refresh_button_label,
+        has_sy6974b,
+        spi_bus: epd_spi_bus,
+        epd,
+        i2c0,
+        flash: peripherals.FLASH,
+        lpwr: peripherals.LPWR,
+        wifi: peripherals.WIFI,
+        battery_enable_pin: peripherals.GPIO21,
+        adc1: peripherals.ADC1,
+        battery_sense: peripherals.GPIO1,
+        ledc: peripherals.LEDC,
+        buzzer_pin: peripherals.GPIO45,
+    };
+
+    run_app(spawner, board).await
+}

--- a/src/bin/e1002.rs
+++ b/src/bin/e1002.rs
@@ -1,0 +1,107 @@
+#![no_std]
+#![no_main]
+#![deny(
+    clippy::mem_forget,
+    reason = "mem::forget is generally not safe to do with esp_hal types, especially those \
+    holding buffers for the duration of a data transfer."
+)]
+
+use embassy_executor::Spawner;
+use esp_hal::clock::CpuClock;
+
+use esp_hal::gpio::{Input, InputConfig, Pin, Pull};
+use esp_hal::gpio::{Level, Output, OutputConfig};
+
+use esp_hal::spi::Mode as SpiMode;
+use esp_hal::spi::master::Config as SpiConfig;
+use esp_hal::spi::master::Spi;
+
+extern crate alloc;
+
+use epd_photoframe::app::{AppHardware, init_runtime, run_app};
+use epd_photoframe::panel::gdep073e01::Gdep073e01;
+
+// This creates a default app-descriptor required by the esp-idf bootloader.
+// For more information see: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/app_image_format.html#application-description>
+esp_bootloader_esp_idf::esp_app_desc!();
+
+#[esp_rtos::main]
+async fn main(spawner: Spawner) -> ! {
+    let config = esp_hal::Config::default().with_cpu_clock(CpuClock::max());
+    let peripherals = esp_hal::init(config);
+
+    init_runtime(
+        peripherals.PSRAM,
+        peripherals.TIMG0,
+        peripherals.SW_INTERRUPT,
+    );
+
+    let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next, led_pin) = (
+        peripherals.GPIO3,
+        peripherals.GPIO5,
+        peripherals.GPIO4,
+        peripherals.GPIO6,
+    );
+
+    // E1001 / E1002 appear to have an SY6974B on I2C1, but it is not
+    // accessible from this firmware setup, so normal-mode power status
+    // reporting is disabled for them.
+    let (refresh_button_label, has_sy6974b) = ("Refresh button (green)", false);
+
+    // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
+    let epd_spi_bus = Spi::new(
+        peripherals.SPI2,
+        SpiConfig::default()
+            .with_write_bit_order(esp_hal::spi::BitOrder::MsbFirst)
+            .with_frequency(esp_hal::time::Rate::from_mhz(20))
+            .with_mode(SpiMode::_0),
+    )
+    .unwrap();
+
+    let mut epd_spi_bus = epd_spi_bus
+        .with_sck(peripherals.GPIO7)
+        .with_mosi(peripherals.GPIO9)
+        .into_async();
+
+    let epd = Gdep073e01::new(
+        &mut epd_spi_bus,
+        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
+        Input::new(
+            peripherals.GPIO13,
+            InputConfig::default().with_pull(Pull::Up),
+        ),
+        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
+        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
+    );
+
+    // One task later drives both per-wake sensor reads (battery ADC +
+    // SHT40 over I²C0) concurrently via `join`.
+    let i2c0 =
+        esp_hal::i2c::master::I2c::new(peripherals.I2C0, esp_hal::i2c::master::Config::default())
+            .unwrap()
+            .with_sda(peripherals.GPIO19)
+            .with_scl(peripherals.GPIO20)
+            .into_async();
+
+    let board = AppHardware {
+        gpio_btn_refresh: gpio_btn_refresh.degrade(),
+        gpio_btn_previous: gpio_btn_previous.degrade(),
+        gpio_btn_next: gpio_btn_next.degrade(),
+        led_pin: led_pin.degrade(),
+        refresh_button_label,
+        has_sy6974b,
+        spi_bus: epd_spi_bus,
+        epd,
+        i2c0,
+        flash: peripherals.FLASH,
+        lpwr: peripherals.LPWR,
+        wifi: peripherals.WIFI,
+        battery_enable_pin: peripherals.GPIO21,
+        adc1: peripherals.ADC1,
+        battery_sense: peripherals.GPIO1,
+        ledc: peripherals.LEDC,
+        buzzer_pin: peripherals.GPIO45,
+    };
+
+    run_app(spawner, board).await
+}

--- a/src/bin/e1004.rs
+++ b/src/bin/e1004.rs
@@ -19,12 +19,6 @@ use esp_hal::spi::master::Spi;
 extern crate alloc;
 
 use epd_photoframe::app::{AppHardware, init_runtime, run_app};
-
-#[cfg(feature = "e1002")]
-use epd_photoframe::panel::gdep073e01::Gdep073e01;
-#[cfg(feature = "e1001")]
-use epd_photoframe::panel::gdey075t7::Gdey075t7;
-#[cfg(feature = "e1004")]
 use epd_photoframe::panel::t133a01::T133A01;
 
 // This creates a default app-descriptor required by the esp-idf bootloader.
@@ -42,18 +36,6 @@ async fn main(spawner: Spawner) -> ! {
         peripherals.SW_INTERRUPT,
     );
 
-    // Bind semantic board pins to device-specific GPIOs. This is the
-    // only place where the silkscreen-to-GPIO and status LED mappings
-    // appear; everything downstream uses the semantic local names.
-    // E1001 inherits the E1002 mapping (same hardware aside from the panel).
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
-    let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next, led_pin) = (
-        peripherals.GPIO3,
-        peripherals.GPIO5,
-        peripherals.GPIO4,
-        peripherals.GPIO6,
-    );
-    #[cfg(feature = "e1004")]
     let (gpio_btn_refresh, gpio_btn_previous, gpio_btn_next, led_pin) = (
         peripherals.GPIO5,
         peripherals.GPIO4,
@@ -61,12 +43,6 @@ async fn main(spawner: Spawner) -> ! {
         peripherals.GPIO48,
     );
 
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
-    // E1001 / E1002 appear to have an SY6974B on I2C1, but it is not
-    // accessible from this firmware setup, so normal-mode power status
-    // reporting is disabled for them.
-    let (refresh_button_label, has_sy6974b) = ("Refresh button (green)", false);
-    #[cfg(feature = "e1004")]
     let (refresh_button_label, has_sy6974b) = ("Refresh button", true);
 
     // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
@@ -79,44 +55,12 @@ async fn main(spawner: Spawner) -> ! {
     )
     .unwrap();
 
-    #[cfg(any(feature = "e1001", feature = "e1002"))]
-    let mut epd_spi_bus = epd_spi_bus
-        .with_sck(peripherals.GPIO7)
-        .with_mosi(peripherals.GPIO9)
-        .into_async();
-
-    #[cfg(feature = "e1004")]
     let mut epd_spi_bus = epd_spi_bus
         .with_sck(peripherals.GPIO7)
         .with_miso(peripherals.GPIO8)
         .with_mosi(peripherals.GPIO9)
         .into_async();
 
-    #[cfg(feature = "e1001")]
-    let epd = Gdey075t7::new(
-        &mut epd_spi_bus,
-        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
-        Input::new(
-            peripherals.GPIO13,
-            InputConfig::default().with_pull(Pull::Up),
-        ),
-        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
-        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
-    );
-
-    #[cfg(feature = "e1002")]
-    let epd = Gdep073e01::new(
-        &mut epd_spi_bus,
-        Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
-        Input::new(
-            peripherals.GPIO13,
-            InputConfig::default().with_pull(Pull::Up),
-        ),
-        Output::new(peripherals.GPIO11, Level::Low, OutputConfig::default()),
-        Output::new(peripherals.GPIO12, Level::Low, OutputConfig::default()),
-    );
-
-    #[cfg(feature = "e1004")]
     let epd = T133A01::new(
         &mut epd_spi_bus,
         Output::new(peripherals.GPIO10, Level::Low, OutputConfig::default()),
@@ -146,7 +90,7 @@ async fn main(spawner: Spawner) -> ! {
     // anything else runs so the system rail spends as little time as
     // possible drawing through VBUS. This must happen after I²C0 is up
     // (the chip lives on this bus).
-    #[cfg(all(feature = "e1004", feature = "disable_charger"))]
+    #[cfg(feature = "disable_charger")]
     let i2c0 = epd_photoframe::sy6974b::enter_measurement_mode(i2c0).await;
 
     let board = AppHardware {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,15 +1,6 @@
 #![no_std]
 extern crate alloc;
 
-#[cfg(all(feature = "e1001", feature = "e1002"))]
-compile_error!("features `e1001` and `e1002` are mutually exclusive");
-#[cfg(all(feature = "e1001", feature = "e1004"))]
-compile_error!("features `e1001` and `e1004` are mutually exclusive");
-#[cfg(all(feature = "e1002", feature = "e1004"))]
-compile_error!("features `e1002` and `e1004` are mutually exclusive");
-#[cfg(not(any(feature = "e1001", feature = "e1002", feature = "e1004")))]
-compile_error!("enable one of the device features: `e1001`, `e1002`, or `e1004`");
-
 pub mod app;
 pub mod battery;
 pub mod button;


### PR DESCRIPTION
## Summary
- replace the feature-selected src/bin/main.rs entrypoint with src/bin/e1001.rs, src/bin/e1002.rs, and src/bin/e1004.rs
- remove e1001/e1002/e1004 Cargo features and lib-level feature sanity checks
- update run.sh, README, and the pre-commit hook to select devices with --bin instead of device features

## Notes
- disable_charger remains a Cargo feature for the E1004 measurement-mode build variant
- E1001 and E1002 keep the SY6974B comment and disabled power-status capability in their binaries
- older separate-binary PRs #10 and #11 were closed in favor of this smaller version

## Testing
- source ~/export-esp.sh && cargo fmt --check
- source ~/export-esp.sh && cargo clippy --bins -- -D warnings
- source ~/export-esp.sh && cargo clippy --bin e1004 --features disable_charger -- -D warnings
- source ~/export-esp.sh && .githooks/pre-commit