### PR TITLE
Add panel test mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -32,6 +32,16 @@ pub enum WakeAction {
     Next,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[allow(clippy::enum_variant_names)]
+enum BootButtonHold {
+    PrevNextHeld,
+    AllHeld,
+    NoneHeld,
+}
+
+const BOOT_BUTTON_HOLD_DURATION: Duration = Duration::from_secs(10);
+
 impl WakeAction {
     /// Name of the `action=` query-string parameter to append to the
     /// base URL, or `None` if the base URL should be fetched unchanged.
@@ -362,6 +372,52 @@ async fn blink_task(mut led: Output<'static>) {
     }
 }
 
+async fn check_boot_button_hold(
+    refresh: &mut AnyPin<'static>,
+    previous: &mut AnyPin<'static>,
+    next: &mut AnyPin<'static>,
+) -> BootButtonHold {
+    let mut refresh_input = Input::new(
+        refresh.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    );
+    let mut previous_input = Input::new(
+        previous.reborrow(),
+        InputConfig::default().with_pull(Pull::Up),
+    );
+    let mut next_input = Input::new(next.reborrow(), InputConfig::default().with_pull(Pull::Up));
+    let hold_deadline = Instant::MIN + BOOT_BUTTON_HOLD_DURATION;
+
+    // First give all three buttons the full hold window. If the timeout wins,
+    // all three buttons stayed pressed long enough to enter test mode.
+    match embassy_futures::select::select4(
+        refresh_input.wait_for_high(),
+        previous_input.wait_for_high(),
+        next_input.wait_for_high(),
+        Timer::at(hold_deadline),
+    )
+    .await
+    {
+        embassy_futures::select::Either4::Fourth(_) => return BootButtonHold::AllHeld,
+        embassy_futures::select::Either4::First(_) => (),
+        _ => return BootButtonHold::NoneHeld,
+    }
+
+    // Refresh was released before the hold window expired. Keep waiting until
+    // the original deadline: if Previous and Next stay pressed, enter config
+    // mode; if either is released first, continue normal boot.
+    match embassy_futures::select::select3(
+        previous_input.wait_for_high(),
+        next_input.wait_for_high(),
+        Timer::at(hold_deadline),
+    )
+    .await
+    {
+        embassy_futures::select::Either3::Third(_) => BootButtonHold::PrevNextHeld,
+        _ => BootButtonHold::NoneHeld,
+    }
+}
+
 /// The non-panic boot path: flip the panic-reboot guard on, kick off
 /// the white pre-flash, run the config-mode hold race, and dispatch
 /// to either `normal_mode::run` (we have credentials and the user isn't
@@ -412,42 +468,19 @@ where
         hw.epd.display_frame_no_wait(&mut hw.spi_bus).await.unwrap();
     }
 
-    // If NVS didn't produce a full set of credentials we go straight to
-    // config mode without the button race. Otherwise: race a 10-second
-    // timer against either Previous or Next being released — if both were
-    // held at boot and stay held for the whole window, the timer wins and
-    // we enter configuration mode. If either (or both) was never pressed,
-    // `wait_for_high` resolves immediately because the pin is already high,
-    // so normally this block completes in microseconds.
-    let entering_config_mode = !config.is_configured().unwrap_or(false) || {
-        let mut prev_input = Input::new(
-            hw.gpio_btn_previous.reborrow(),
-            InputConfig::default().with_pull(Pull::Up),
-        );
-        let mut next_input = Input::new(
-            hw.gpio_btn_next.reborrow(),
-            InputConfig::default().with_pull(Pull::Up),
-        );
-        matches!(
-            embassy_futures::select::select3(
-                prev_input.wait_for_high(),
-                next_input.wait_for_high(),
-                Timer::at(Instant::MIN + Duration::from_secs(10)),
-            )
-            .await,
-            embassy_futures::select::Either3::Third(_)
-        )
-    };
+    let boot_button_hold = check_boot_button_hold(
+        &mut hw.gpio_btn_refresh,
+        &mut hw.gpio_btn_previous,
+        &mut hw.gpio_btn_next,
+    )
+    .await;
 
-    if !entering_config_mode {
-        crate::normal_mode::run(hw, config).await
-    } else {
-        // Entering config mode is a deliberate reset of the device's
-        // "what's displayed" state — whatever URL was committed last
-        // cycle (and any pending redirect) is no longer relevant once
-        // the user has reconfigured.
-        crate::normal_mode::CURRENT_URL.clear();
-        crate::normal_mode::REDIRECT_URL.clear();
-        config_mode::run(hw, config).await
+    match boot_button_hold {
+        BootButtonHold::AllHeld => crate::test_mode::run(hw).await,
+        BootButtonHold::PrevNextHeld => config_mode::run(hw, config).await,
+        BootButtonHold::NoneHeld if !config.is_configured().unwrap_or(false) => {
+            config_mode::run(hw, config).await
+        }
+        BootButtonHold::NoneHeld => crate::normal_mode::run(hw, config).await,
     }
 }

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -31,6 +31,28 @@ impl<C: PixelColor> Canvas<C> {
         }
     }
 
+    /// Allocate a `width × height` canvas initialized from a coordinate
+    /// function.
+    pub fn new_with<F>(width: u32, height: u32, mut color_at: F) -> Self
+    where
+        F: FnMut(u32, u32) -> C,
+    {
+        let len = (width as usize) * (height as usize);
+        let mut idx = 0;
+        let mut pixels = Vec::new();
+        pixels.resize_with(len, || {
+            let x = idx % width;
+            let y = idx / width;
+            idx += 1;
+            color_at(x, y)
+        });
+        Self {
+            pixels,
+            width,
+            height,
+        }
+    }
+
     /// Consume the canvas and return its underlying row-major pixel
     /// buffer.
     pub fn into_vec(self) -> Vec<C> {

--- a/src/config_mode.rs
+++ b/src/config_mode.rs
@@ -28,6 +28,12 @@ pub async fn run<P>(ctx: AppContext<P>, mut nvs: Config<'static>) -> !
 where
     P: Panel<Spi<'static, esp_hal::Async>>,
 {
+    // Entering config mode deliberately resets the device's "what's displayed"
+    // state: whatever URL was committed last cycle (and any pending redirect)
+    // is no longer relevant once the user has reconfigured.
+    crate::normal_mode::CURRENT_URL.clear();
+    crate::normal_mode::REDIRECT_URL.clear();
+
     let AppContext {
         spawner,
         wifi,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,5 +21,6 @@ pub mod sht40;
 pub mod single_shot_wifi;
 pub mod sleep;
 pub mod sy6974b;
+pub mod test_mode;
 pub mod uart;
 pub mod url_util;

--- a/src/test_mode.rs
+++ b/src/test_mode.rs
@@ -1,0 +1,144 @@
+//! Panel test mode: render every paint colour in the panel palette as
+//! full-height or full-width bands. Entered with a three-button boot hold.
+
+use alloc::vec::Vec;
+
+use embassy_time::Duration;
+use embedded_graphics::Drawable;
+use embedded_graphics::mono_font::ascii::FONT_10X20;
+use embedded_graphics::mono_font::{MonoFont, MonoTextStyle};
+use embedded_graphics::prelude::{Point, Primitive, Size};
+use embedded_graphics::primitives::{PrimitiveStyle, Rectangle};
+use embedded_text::TextBox;
+use esp_hal::gpio::{Input, InputConfig, Pull};
+use esp_hal::spi::master::Spi;
+use esp_println::println;
+
+use crate::app::AppContext;
+use crate::button::wait_for_press;
+use crate::canvas::Canvas;
+use crate::panel::{Panel, PanelColor};
+
+pub async fn run<P>(mut ctx: AppContext<P>) -> !
+where
+    P: Panel<Spi<'static, esp_hal::Async>>,
+{
+    println!("Test mode");
+    println!("Test mode - beep");
+    ctx.buzzer.beep(Duration::from_millis(80)).await;
+
+    let frame = render_swatch::<P::Color>(P::WIDTH, P::HEIGHT, ctx.refresh_button_label);
+    let init_mode = P::init_mode_for_palette(P::Color::all());
+
+    ctx.epd.enable().await.unwrap();
+    println!("Reset");
+    ctx.epd.reset().await.unwrap();
+    println!("Wait until idle");
+    ctx.epd.wait_until_idle().await.unwrap();
+    println!("Init");
+    ctx.epd.init(&mut ctx.spi_bus, init_mode).await.unwrap();
+    println!("Power on");
+    ctx.epd.power_on(&mut ctx.spi_bus).await.unwrap();
+    println!("Update frame (test swatch)");
+    let data = (0..(P::WIDTH * P::HEIGHT)).map(|idx| {
+        let (x, y) = P::output_index_to_image_xy(idx);
+        frame[y * P::WIDTH + x]
+    });
+    ctx.epd.update_frame(&mut ctx.spi_bus, data).await.unwrap();
+    println!("Trigger refresh");
+    ctx.epd
+        .display_frame_no_wait(&mut ctx.spi_bus)
+        .await
+        .unwrap();
+    println!("Wait until idle (~20s refresh)");
+    ctx.epd.wait_until_idle().await.unwrap();
+    println!("Power off");
+    ctx.epd.power_off(&mut ctx.spi_bus).await.unwrap();
+    ctx.epd.disable().await.unwrap();
+
+    println!("Test mode done — press Refresh to reboot");
+    let mut refresh_input = Input::new(
+        ctx.gpio_btn_refresh,
+        InputConfig::default().with_pull(Pull::Up),
+    );
+    refresh_input.wait_for_high().await;
+    wait_for_press(&mut refresh_input, Duration::from_millis(50)).await;
+    println!("Rebooting");
+    esp_hal::system::software_reset();
+}
+
+fn render_swatch<C: PanelColor>(width: usize, height: usize, refresh_button_label: &str) -> Vec<C> {
+    let colors: Vec<C> = C::all().collect();
+    let fallback = C::WHITE;
+    let count = colors.len().max(1);
+
+    let mut canvas = Canvas::new_with(width as u32, height as u32, |x, y| {
+        let (x, y) = (x as usize, y as usize);
+        let band = if width >= height {
+            x * count / width
+        } else {
+            y * count / height
+        };
+        colors.get(band).copied().unwrap_or(fallback)
+    });
+
+    draw_instructions(
+        &mut canvas,
+        width as u32,
+        height as u32,
+        refresh_button_label,
+    );
+    canvas.into_vec()
+}
+
+fn draw_instructions<C: PanelColor>(
+    canvas: &mut Canvas<C>,
+    width: u32,
+    height: u32,
+    refresh_button_label: &str,
+) {
+    const BOX_PADDING_PX: u32 = 24;
+    let text = alloc::format!(
+        "Test mode active\nDevice remains powered on\nPress {} to reboot",
+        refresh_button_label
+    );
+    let text_width = text_width_px(&text, &FONT_10X20);
+    let text_height = text_height_px(&text, &FONT_10X20);
+    let max_text_width = width.saturating_sub(2 * BOX_PADDING_PX);
+    let text_width = text_width.min(max_text_width);
+
+    let box_width = (text_width + 2 * BOX_PADDING_PX).min(width);
+    let box_height = (text_height + 2 * BOX_PADDING_PX).min(height);
+    let box_x = ((width - box_width) / 2) as i32;
+    let box_y = ((height - box_height) / 2) as i32;
+    let box_area = Rectangle::new(Point::new(box_x, box_y), Size::new(box_width, box_height));
+
+    let _ = box_area
+        .into_styled(PrimitiveStyle::with_fill(C::WHITE))
+        .draw(canvas);
+    let _ = box_area
+        .into_styled(PrimitiveStyle::with_stroke(C::BLACK, 2))
+        .draw(canvas);
+
+    let text_width = box_width.saturating_sub(2 * BOX_PADDING_PX);
+    let text_height = box_height.saturating_sub(2 * BOX_PADDING_PX);
+    let text_area = Rectangle::new(
+        Point::new(box_x + BOX_PADDING_PX as i32, box_y + BOX_PADDING_PX as i32),
+        Size::new(text_width, text_height),
+    );
+    let style = MonoTextStyle::new(&FONT_10X20, C::BLACK);
+    let _ = TextBox::new(&text, text_area, style).draw(canvas);
+}
+
+fn text_width_px(text: &str, font: &MonoFont<'_>) -> u32 {
+    let char_width = font.character_size.width;
+    text.lines()
+        .map(|line| line.chars().count() as u32 * char_width)
+        .max()
+        .unwrap_or(0)
+}
+
+fn text_height_px(text: &str, font: &MonoFont<'_>) -> u32 {
+    let line_count = text.lines().count().max(1) as u32;
+    line_count * font.character_size.height
+}


### PR DESCRIPTION
## Summary
- add a three-button boot hold that enters panel test mode before normal/config dispatch
- render every panel paint colour as full-screen swatch bands, vertical on landscape panels and horizontal on portrait panels
- show a centered instruction box over the swatch and require Refresh release before accepting Refresh to reboot

## Notes
This is expected to get more changes before merge. Follow-ups planned:
- clean up selection of which mode to boot
- add a UART terminal in test mode to display specific colours/patterns

## Testing
- source ~/export-esp.sh && .githooks/pre-commit