### PR TITLE
Add UART color commands to test mode

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -9,6 +9,7 @@ use esp_hal::gpio::{AnyPin, Input, InputConfig, Level, Output, OutputConfig, Pin
 use esp_hal::spi::master::Spi;
 use esp_hal::system::SleepSource;
 use esp_hal::timer::timg::TimerGroup;
+use esp_hal::uart::UartRx;
 use esp_println::println;
 
 use crate::buzzer::Buzzer;
@@ -74,6 +75,7 @@ pub struct AppHardware<P> {
     pub led_pin: AnyPin<'static>,
     pub refresh_button_label: &'static str,
     pub has_sy6974b: bool,
+    pub uart_rx: UartRx<'static, esp_hal::Async>,
     pub spi_bus: Spi<'static, esp_hal::Async>,
     pub epd: P,
     pub i2c0: esp_hal::i2c::master::I2c<'static, esp_hal::Async>,
@@ -98,6 +100,7 @@ pub struct AppContext<P> {
     pub wifi: esp_hal::peripherals::WIFI<'static>,
     pub refresh_button_label: &'static str,
     pub has_sy6974b: bool,
+    pub uart_rx: UartRx<'static, esp_hal::Async>,
 
     /// Sensor hardware used only by the normal refresh flow to populate
     /// battery / temperature / humidity / charger status URL parameters.
@@ -158,6 +161,7 @@ where
         led_pin,
         refresh_button_label,
         has_sy6974b,
+        uart_rx,
         spi_bus,
         epd,
         i2c0,
@@ -257,6 +261,7 @@ where
         wifi,
         refresh_button_label,
         has_sy6974b,
+        uart_rx,
         battery_enable: Output::new(battery_enable_pin, Level::Low, OutputConfig::default()),
         adc1,
         battery_sense,

--- a/src/bin/e1001.rs
+++ b/src/bin/e1001.rs
@@ -15,6 +15,7 @@ use esp_hal::gpio::{Level, Output, OutputConfig};
 use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
+use esp_hal::uart::{Config as UartConfig, UartRx};
 
 extern crate alloc;
 
@@ -47,6 +48,10 @@ async fn main(spawner: Spawner) -> ! {
     // accessible from this firmware setup, so normal-mode power status
     // reporting is disabled for them.
     let (refresh_button_label, has_sy6974b) = ("Refresh button (green)", false);
+    let uart_rx = UartRx::new(peripherals.UART0, UartConfig::default())
+        .unwrap()
+        .with_rx(peripherals.GPIO44)
+        .into_async();
 
     // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
     let epd_spi_bus = Spi::new(
@@ -90,6 +95,7 @@ async fn main(spawner: Spawner) -> ! {
         led_pin: led_pin.degrade(),
         refresh_button_label,
         has_sy6974b,
+        uart_rx,
         spi_bus: epd_spi_bus,
         epd,
         i2c0,

--- a/src/bin/e1002.rs
+++ b/src/bin/e1002.rs
@@ -15,6 +15,7 @@ use esp_hal::gpio::{Level, Output, OutputConfig};
 use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
+use esp_hal::uart::{Config as UartConfig, UartRx};
 
 extern crate alloc;
 
@@ -47,6 +48,10 @@ async fn main(spawner: Spawner) -> ! {
     // accessible from this firmware setup, so normal-mode power status
     // reporting is disabled for them.
     let (refresh_button_label, has_sy6974b) = ("Refresh button (green)", false);
+    let uart_rx = UartRx::new(peripherals.UART0, UartConfig::default())
+        .unwrap()
+        .with_rx(peripherals.GPIO44)
+        .into_async();
 
     // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
     let epd_spi_bus = Spi::new(
@@ -90,6 +95,7 @@ async fn main(spawner: Spawner) -> ! {
         led_pin: led_pin.degrade(),
         refresh_button_label,
         has_sy6974b,
+        uart_rx,
         spi_bus: epd_spi_bus,
         epd,
         i2c0,

--- a/src/bin/e1004.rs
+++ b/src/bin/e1004.rs
@@ -15,6 +15,7 @@ use esp_hal::gpio::{Level, Output, OutputConfig};
 use esp_hal::spi::Mode as SpiMode;
 use esp_hal::spi::master::Config as SpiConfig;
 use esp_hal::spi::master::Spi;
+use esp_hal::uart::{Config as UartConfig, UartRx};
 
 extern crate alloc;
 
@@ -44,6 +45,10 @@ async fn main(spawner: Spawner) -> ! {
     );
 
     let (refresh_button_label, has_sy6974b) = ("Refresh button", true);
+    let uart_rx = UartRx::new(peripherals.UART0, UartConfig::default())
+        .unwrap()
+        .with_rx(peripherals.GPIO44)
+        .into_async();
 
     // --- Build the panel SPI bus and EPD driver (shared by both flows) ---
     let epd_spi_bus = Spi::new(
@@ -100,6 +105,7 @@ async fn main(spawner: Spawner) -> ! {
         led_pin: led_pin.degrade(),
         refresh_button_label,
         has_sy6974b,
+        uart_rx,
         spi_bus: epd_spi_bus,
         epd,
         i2c0,

--- a/src/test_mode.rs
+++ b/src/test_mode.rs
@@ -1,6 +1,7 @@
 //! Panel test mode: render every paint colour in the panel palette as
 //! full-height or full-width bands. Entered with a three-button boot hold.
 
+use alloc::format;
 use alloc::vec::Vec;
 
 use embassy_time::Duration;
@@ -12,6 +13,7 @@ use embedded_graphics::primitives::{PrimitiveStyle, Rectangle};
 use embedded_text::TextBox;
 use esp_hal::gpio::{Input, InputConfig, Pull};
 use esp_hal::spi::master::Spi;
+use esp_hal::uart::UartRx;
 use esp_println::println;
 
 use crate::app::AppContext;
@@ -19,52 +21,85 @@ use crate::button::wait_for_press;
 use crate::canvas::Canvas;
 use crate::panel::{Panel, PanelColor};
 
-pub async fn run<P>(mut ctx: AppContext<P>) -> !
+pub async fn run<P>(ctx: AppContext<P>) -> !
 where
     P: Panel<Spi<'static, esp_hal::Async>>,
 {
+    let refresh_button_label = ctx.refresh_button_label;
+    let mut buzzer = ctx.buzzer;
+    let mut gpio_btn_refresh = ctx.gpio_btn_refresh;
+    let mut spi_bus = ctx.spi_bus;
+    let mut epd = ctx.epd;
+    let mut uart_rx = ctx.uart_rx;
+
     println!("Test mode");
     println!("Test mode - beep");
-    ctx.buzzer.beep(Duration::from_millis(80)).await;
+    buzzer.beep(Duration::from_millis(80)).await;
 
-    let frame = render_swatch::<P::Color>(P::WIDTH, P::HEIGHT, ctx.refresh_button_label);
-    let init_mode = P::init_mode_for_palette(P::Color::all());
-
-    ctx.epd.enable().await.unwrap();
-    println!("Reset");
-    ctx.epd.reset().await.unwrap();
-    println!("Wait until idle");
-    ctx.epd.wait_until_idle().await.unwrap();
-    println!("Init");
-    ctx.epd.init(&mut ctx.spi_bus, init_mode).await.unwrap();
-    println!("Power on");
-    ctx.epd.power_on(&mut ctx.spi_bus).await.unwrap();
-    println!("Update frame (test swatch)");
-    let data = (0..(P::WIDTH * P::HEIGHT)).map(|idx| {
-        let (x, y) = P::output_index_to_image_xy(idx);
-        frame[y * P::WIDTH + x]
-    });
-    ctx.epd.update_frame(&mut ctx.spi_bus, data).await.unwrap();
-    println!("Trigger refresh");
-    ctx.epd
-        .display_frame_no_wait(&mut ctx.spi_bus)
-        .await
-        .unwrap();
-    println!("Wait until idle (~20s refresh)");
-    ctx.epd.wait_until_idle().await.unwrap();
-    println!("Power off");
-    ctx.epd.power_off(&mut ctx.spi_bus).await.unwrap();
-    ctx.epd.disable().await.unwrap();
-
-    println!("Test mode done — press Refresh to reboot");
     let mut refresh_input = Input::new(
-        ctx.gpio_btn_refresh,
+        gpio_btn_refresh.reborrow(),
         InputConfig::default().with_pull(Pull::Up),
     );
-    refresh_input.wait_for_high().await;
-    wait_for_press(&mut refresh_input, Duration::from_millis(50)).await;
+    let refresh_pressed = async {
+        refresh_input.wait_for_high().await;
+        wait_for_press(&mut refresh_input, Duration::from_millis(50)).await;
+    };
+
+    let _ = embassy_futures::select::select(
+        refresh_pressed,
+        main_loop::<P>(&mut spi_bus, &mut epd, &mut uart_rx, refresh_button_label),
+    )
+    .await;
     println!("Rebooting");
     esp_hal::system::software_reset();
+}
+
+async fn main_loop<P>(
+    spi_bus: &mut Spi<'static, esp_hal::Async>,
+    epd: &mut P,
+    uart_rx: &mut UartRx<'static, esp_hal::Async>,
+    refresh_button_label: &'static str,
+) where
+    P: Panel<Spi<'static, esp_hal::Async>>,
+{
+    let colors: Vec<P::Color> = P::Color::all().collect();
+    render_test_frame::<P>(
+        spi_bus,
+        epd,
+        render_swatch::<P::Color>(P::WIDTH, P::HEIGHT, refresh_button_label),
+        "test swatch",
+    )
+    .await;
+
+    println!("Test mode ready. Send `COLOR number` over UART, or press Refresh to reboot.");
+    loop {
+        match read_command(uart_rx).await {
+            TestCommand::Color(index) => {
+                if let Some(color) = colors.get(index).copied() {
+                    println!("Rendering COLOR {}", index);
+                    render_test_frame::<P>(
+                        spi_bus,
+                        epd,
+                        render_solid_color::<P::Color>(
+                            P::WIDTH,
+                            P::HEIGHT,
+                            color,
+                            refresh_button_label,
+                        ),
+                        "solid color",
+                    )
+                    .await;
+                    println!("Test mode ready.");
+                } else {
+                    println!(
+                        "Unknown COLOR index {}. Valid range: 0..{}",
+                        index,
+                        colors.len()
+                    );
+                }
+            }
+        }
+    }
 }
 
 fn render_swatch<C: PanelColor>(width: usize, height: usize, refresh_button_label: &str) -> Vec<C> {
@@ -91,6 +126,114 @@ fn render_swatch<C: PanelColor>(width: usize, height: usize, refresh_button_labe
     canvas.into_vec()
 }
 
+fn render_solid_color<C: PanelColor>(
+    width: usize,
+    height: usize,
+    color: C,
+    refresh_button_label: &str,
+) -> Vec<C> {
+    let mut canvas = Canvas::new(width as u32, height as u32, color);
+    draw_instructions(
+        &mut canvas,
+        width as u32,
+        height as u32,
+        refresh_button_label,
+    );
+    canvas.into_vec()
+}
+
+async fn render_test_frame<P>(
+    spi_bus: &mut Spi<'static, esp_hal::Async>,
+    epd: &mut P,
+    frame: Vec<P::Color>,
+    label: &str,
+) where
+    P: Panel<Spi<'static, esp_hal::Async>>,
+{
+    let init_mode = P::init_mode_for_palette(P::Color::all());
+
+    epd.enable().await.unwrap();
+    println!("Reset");
+    epd.reset().await.unwrap();
+    println!("Wait until idle");
+    epd.wait_until_idle().await.unwrap();
+    println!("Init");
+    epd.init(spi_bus, init_mode).await.unwrap();
+    println!("Power on");
+    epd.power_on(spi_bus).await.unwrap();
+    println!("Update frame ({})", label);
+    let data = (0..(P::WIDTH * P::HEIGHT)).map(|idx| {
+        let (x, y) = P::output_index_to_image_xy(idx);
+        frame[y * P::WIDTH + x]
+    });
+    epd.update_frame(spi_bus, data).await.unwrap();
+    println!("Trigger refresh");
+    epd.display_frame_no_wait(spi_bus).await.unwrap();
+    println!("Wait until idle (~20s refresh)");
+    epd.wait_until_idle().await.unwrap();
+    println!("Power off");
+    epd.power_off(spi_bus).await.unwrap();
+    epd.disable().await.unwrap();
+}
+
+enum TestCommand {
+    Color(usize),
+}
+
+async fn read_command(uart_rx: &mut UartRx<'static, esp_hal::Async>) -> TestCommand {
+    let mut line = heapless::String::<64>::new();
+    loop {
+        if let Some(byte) = read_byte(uart_rx).await
+            && let Some(command) = handle_command_byte(byte, &mut line)
+        {
+            return command;
+        }
+    }
+}
+
+fn handle_command_byte(byte: u8, line: &mut heapless::String<64>) -> Option<TestCommand> {
+    match byte {
+        b'\n' => {
+            if let Some(command) = parse_command(line.trim()) {
+                return Some(command);
+            }
+            println!("Unknown test command: {:?}", line.as_str());
+            line.clear();
+        }
+        b'\r' => {}
+        byte => {
+            if line.push(byte as char).is_err() {
+                println!("Test command too long; clearing input");
+                line.clear();
+            }
+        }
+    }
+
+    None
+}
+
+async fn read_byte(uart_rx: &mut UartRx<'static, esp_hal::Async>) -> Option<u8> {
+    let mut byte = [0];
+    match uart_rx.read_async(&mut byte).await {
+        Ok(1) => Some(byte[0]),
+        Ok(_) => None,
+        Err(e) => {
+            println!("UART RX error: {:?}", e);
+            None
+        }
+    }
+}
+
+fn parse_command(line: &str) -> Option<TestCommand> {
+    let mut parts = line.split_whitespace();
+    match (parts.next(), parts.next(), parts.next()) {
+        (Some(command), Some(index), None) if command.eq_ignore_ascii_case("COLOR") => {
+            index.parse().ok().map(TestCommand::Color)
+        }
+        _ => None,
+    }
+}
+
 fn draw_instructions<C: PanelColor>(
     canvas: &mut Canvas<C>,
     width: u32,
@@ -98,7 +241,7 @@ fn draw_instructions<C: PanelColor>(
     refresh_button_label: &str,
 ) {
     const BOX_PADDING_PX: u32 = 24;
-    let text = alloc::format!(
+    let text = format!(
         "Test mode active\nDevice remains powered on\nPress {} to reboot",
         refresh_button_label
     );


### PR DESCRIPTION
## Summary
- pass an owned UART0 RX driver into the shared app context while leaving esp-println on its existing TX path
- keep test mode active after the initial swatch render and accept UART commands
- add `COLOR number` to repaint the panel to a single palette color with the test-mode instruction box still overlaid

## Validation
- `source /home/claude/export-esp.sh && .githooks/pre-commit`

## Notes
- Assumes UART0 RX is available on GPIO44 for the E1001/E1002/E1004 boards; this should be validated on hardware.