### PR TITLE
Add power measurement mode

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -7,5 +7,5 @@ cargo fmt --check
 echo "Checking clippy for all binaries..."
 cargo clippy --bins -- -D warnings
 
-echo "Checking clippy for e1004 + disable_charger..."
-cargo clippy --bin e1004 --features disable_charger -- -D warnings
+echo "Checking clippy for all binaries + power_measurement..."
+cargo clippy --bins --features power_measurement -- -D warnings

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,17 +5,12 @@ rust-version = "1.91"
 version      = "0.1.0"
 
 [features]
-# PPK2 bench-measurement mode (E1004 only). On boot, parks the SY6974B
-# charger in HIZ so the system rail runs entirely from the BAT input,
-# regardless of USB-C state. Intended for a Nordic Power Profiler Kit II
-# in source mode wired to the BAT pins (replacing the cell): PPK2
-# supplies a constant voltage and measures the real system current while
-# USB-C stays connected for `esptool` flash and the CH340K serial console
-# (CH340K is powered from VBUS via a separate LDO, independent of the
-# charger). Also disables the chip's I²C watchdog so HIZ doesn't
-# auto-clear after 40 s. The cell, if also connected, will not charge
-# while this build runs.
-disable_charger = []
+# Power-measurement mode for PPK2-style bench runs. The generic app always
+# wakes every 30 seconds and marks the panel image so accidental field use is
+# obvious. Boards with an accessible SY6974B (currently E1004) also park the
+# charger in HIZ so the system rail runs entirely from BAT while USB-C stays
+# connected for flashing and the CH340K serial console.
+power_measurement = []
 
 [dependencies]
 esp-hal = { version = "1.1.0", features = ["esp32s3", "unstable"] }

--- a/POWER.md
+++ b/POWER.md
@@ -82,7 +82,7 @@ Two candidate optimisations were investigated; neither shipped.
 The white pre-flash gives ~1 s of immediate visual feedback after a
 button press by kicking off an all-white panel refresh in parallel
 with WiFi fetch. PPK2 measurement of three runs (60 s cold-boot
-captures, `disable_charger` build, 3700 mV):
+captures, `power_measurement` build, 3700 mV):
 
 | Variant | Active-phase energy |
 |---------|---------------------|
@@ -138,18 +138,19 @@ Bench setup notes
 -----------------
 
 PPK2 in source-meter mode replaces the cell at the BAT pads. Build
-with the `disable_charger` Cargo feature, which parks the SY6974B in
-HIZ so the PPK2 sees the real load even with USB-C attached, and
-disables the chip's I²C watchdog so HIZ is sticky across resets:
+with the `power_measurement` Cargo feature, which parks the SY6974B in
+HIZ on E1004 so the PPK2 sees the real load even with USB-C attached,
+forces a 30-second wake interval, and marks the panel image so bench
+firmware is obvious:
 
 ```
-EXTRA_FEATURES=disable_charger RELEASE=1 ./run.sh e1004 /dev/ttyUSB0 /tmp/flash.log
+EXTRA_FEATURES=power_measurement RELEASE=1 ./run.sh e1004 /dev/ttyUSB0 /tmp/flash.log
 ```
 
 Drive the PPK2 from Nordic's nRF Connect for Desktop (Power
 Profiler app) for live current display and capture.
 
-**Bench gotcha:** with `disable_charger` active, EN_HIZ is sticky
+**Bench gotcha:** with `power_measurement` active on E1004, EN_HIZ is sticky
 across ESP32 resets and only clears when VBUS is removed and
 reapplied. Once firmware has run, the device only boots if the PPK2
 is sourcing on BAT — if the supply script exits between flashes, the

--- a/run.sh
+++ b/run.sh
@@ -61,7 +61,7 @@ if [[ "${RELEASE:-}" == "1" ]]; then
     release_flag="--release"
 fi
 # `EXTRA_FEATURES=foo,bar` env var passes extra cargo features — e.g.
-# `disable_charger` for PPK2 bench builds.
+# `power_measurement` for PPK2 bench builds.
 features=""
 if [[ -n "${EXTRA_FEATURES:-}" ]]; then
     features="--features ${EXTRA_FEATURES}"

--- a/src/bin/e1004.rs
+++ b/src/bin/e1004.rs
@@ -91,11 +91,12 @@ async fn main(spawner: Spawner) -> ! {
             .with_scl(peripherals.GPIO20)
             .into_async();
 
-    // PPK2 measurement mode: park the SY6974B charger in HIZ before
+    // Power-measurement mode: park the SY6974B charger in HIZ before
     // anything else runs so the system rail spends as little time as
     // possible drawing through VBUS. This must happen after I²C0 is up
-    // (the chip lives on this bus).
-    #[cfg(feature = "disable_charger")]
+    // (the chip lives on this bus). Other boards still support generic
+    // power-measurement behavior, but do not have an accessible SY6974B.
+    #[cfg(feature = "power_measurement")]
     let i2c0 = epd_photoframe::sy6974b::enter_measurement_mode(i2c0).await;
 
     let board = AppHardware {

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -53,6 +53,16 @@ impl<C: PixelColor> Canvas<C> {
         }
     }
 
+    /// Wrap an existing row-major `width × height` frame buffer.
+    pub fn from_vec(width: u32, height: u32, pixels: Vec<C>) -> Self {
+        debug_assert_eq!(pixels.len(), (width as usize) * (height as usize));
+        Self {
+            pixels,
+            width,
+            height,
+        }
+    }
+
     /// Consume the canvas and return its underlying row-major pixel
     /// buffer.
     pub fn into_vec(self) -> Vec<C> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,5 +22,6 @@ pub mod single_shot_wifi;
 pub mod sleep;
 pub mod sy6974b;
 pub mod test_mode;
+pub mod text_box;
 pub mod uart;
 pub mod url_util;

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -26,6 +26,8 @@ use crate::rtc_persisted::RtcPersisted;
 use crate::sht40;
 use crate::single_shot_wifi;
 use crate::sy6974b;
+#[cfg(feature = "power_measurement")]
+use crate::text_box;
 use crate::uart::wait_for_tx_idle;
 use crate::url_util::{self, parse_http_url};
 
@@ -137,6 +139,8 @@ const DEFAULT_SUCCESS_SLEEP: Duration = Duration::from_secs(4 * 60 * 60);
 /// transient failure (WiFi glitch, server hiccup) recovers on the next
 /// wake without the user having to push a button.
 const DEFAULT_ERROR_SLEEP: Duration = Duration::from_secs(600);
+#[cfg(feature = "power_measurement")]
+const POWER_MEASUREMENT_SLEEP: Duration = Duration::from_secs(30);
 
 /// Optional server hint parsed from the `Refresh:` response header —
 /// carries the target `Instant` at which the next fetch should happen
@@ -400,6 +404,16 @@ where
                 )
             }
         };
+    #[cfg(feature = "power_measurement")]
+    let wakeup_requested = {
+        let _server_wakeup_requested = wakeup_requested;
+        println!("Power measurement mode: forcing 30 second wake interval");
+        embassy_time::Instant::now() + POWER_MEASUREMENT_SLEEP
+    };
+
+    #[cfg(feature = "power_measurement")]
+    let frame = add_power_measurement_overlay(frame, panel_width, panel_height);
+
     let FrameWithPalette { frame, palette } = frame;
 
     // --- Real refresh: reset aborts the (possibly still running) white refresh. ---
@@ -510,6 +524,29 @@ where
         ),
     ];
     crate::sleep::start_sleep(rtc, Some(wakeup_requested), wakeup_pins);
+}
+
+#[cfg(feature = "power_measurement")]
+fn add_power_measurement_overlay<C: PanelColor>(
+    frame: FrameWithPalette<C>,
+    width: usize,
+    height: usize,
+) -> FrameWithPalette<C> {
+    const TEXT: &str =
+        "Power measurement mode\nCharger disabled if supported\nWake interval: 30 seconds";
+
+    let FrameWithPalette { frame, mut palette } = frame;
+    let frame = text_box::draw_centered_on_frame(frame, width as u32, height as u32, TEXT);
+    add_color_if_missing(&mut palette, C::BLACK);
+    add_color_if_missing(&mut palette, C::WHITE);
+    FrameWithPalette { frame, palette }
+}
+
+#[cfg(feature = "power_measurement")]
+fn add_color_if_missing<C: PanelColor>(palette: &mut Vec<C>, color: C) {
+    if !palette.contains(&color) {
+        palette.push(color);
+    }
 }
 
 /// Parse a `Refresh: <secs>[; url=<url>]` header value into a

--- a/src/test_mode.rs
+++ b/src/test_mode.rs
@@ -5,12 +5,6 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use embassy_time::Duration;
-use embedded_graphics::Drawable;
-use embedded_graphics::mono_font::ascii::FONT_10X20;
-use embedded_graphics::mono_font::{MonoFont, MonoTextStyle};
-use embedded_graphics::prelude::{Point, Primitive, Size};
-use embedded_graphics::primitives::{PrimitiveStyle, Rectangle};
-use embedded_text::TextBox;
 use esp_hal::gpio::{Input, InputConfig, Pull};
 use esp_hal::spi::master::Spi;
 use esp_hal::uart::UartRx;
@@ -20,6 +14,7 @@ use crate::app::AppContext;
 use crate::button::wait_for_press;
 use crate::canvas::Canvas;
 use crate::panel::{Panel, PanelColor};
+use crate::text_box;
 
 pub async fn run<P>(ctx: AppContext<P>) -> !
 where
@@ -240,48 +235,9 @@ fn draw_instructions<C: PanelColor>(
     height: u32,
     refresh_button_label: &str,
 ) {
-    const BOX_PADDING_PX: u32 = 24;
     let text = format!(
         "Test mode active\nDevice remains powered on\nPress {} to reboot",
         refresh_button_label
     );
-    let text_width = text_width_px(&text, &FONT_10X20);
-    let text_height = text_height_px(&text, &FONT_10X20);
-    let max_text_width = width.saturating_sub(2 * BOX_PADDING_PX);
-    let text_width = text_width.min(max_text_width);
-
-    let box_width = (text_width + 2 * BOX_PADDING_PX).min(width);
-    let box_height = (text_height + 2 * BOX_PADDING_PX).min(height);
-    let box_x = ((width - box_width) / 2) as i32;
-    let box_y = ((height - box_height) / 2) as i32;
-    let box_area = Rectangle::new(Point::new(box_x, box_y), Size::new(box_width, box_height));
-
-    let _ = box_area
-        .into_styled(PrimitiveStyle::with_fill(C::WHITE))
-        .draw(canvas);
-    let _ = box_area
-        .into_styled(PrimitiveStyle::with_stroke(C::BLACK, 2))
-        .draw(canvas);
-
-    let text_width = box_width.saturating_sub(2 * BOX_PADDING_PX);
-    let text_height = box_height.saturating_sub(2 * BOX_PADDING_PX);
-    let text_area = Rectangle::new(
-        Point::new(box_x + BOX_PADDING_PX as i32, box_y + BOX_PADDING_PX as i32),
-        Size::new(text_width, text_height),
-    );
-    let style = MonoTextStyle::new(&FONT_10X20, C::BLACK);
-    let _ = TextBox::new(&text, text_area, style).draw(canvas);
-}
-
-fn text_width_px(text: &str, font: &MonoFont<'_>) -> u32 {
-    let char_width = font.character_size.width;
-    text.lines()
-        .map(|line| line.chars().count() as u32 * char_width)
-        .max()
-        .unwrap_or(0)
-}
-
-fn text_height_px(text: &str, font: &MonoFont<'_>) -> u32 {
-    let line_count = text.lines().count().max(1) as u32;
-    line_count * font.character_size.height
+    text_box::draw_centered(canvas, width, height, &text);
 }

--- a/src/text_box.rs
+++ b/src/text_box.rs
@@ -1,0 +1,68 @@
+use alloc::vec::Vec;
+
+use embedded_graphics::Drawable;
+use embedded_graphics::mono_font::MonoFont;
+use embedded_graphics::mono_font::MonoTextStyle;
+use embedded_graphics::mono_font::ascii::FONT_10X20;
+use embedded_graphics::prelude::{Point, Primitive, Size};
+use embedded_graphics::primitives::{PrimitiveStyle, Rectangle};
+use embedded_text::TextBox;
+
+use crate::canvas::Canvas;
+use crate::panel::PanelColor;
+
+const BOX_PADDING_PX: u32 = 24;
+
+pub fn draw_centered<C: PanelColor>(canvas: &mut Canvas<C>, width: u32, height: u32, text: &str) {
+    let text_width = text_width_px(text, &FONT_10X20);
+    let text_height = text_height_px(text, &FONT_10X20);
+    let max_text_width = width.saturating_sub(2 * BOX_PADDING_PX);
+    let text_width = text_width.min(max_text_width);
+
+    let box_width = (text_width + 2 * BOX_PADDING_PX).min(width);
+    let box_height = (text_height + 2 * BOX_PADDING_PX).min(height);
+    let box_x = ((width - box_width) / 2) as i32;
+    let box_y = ((height - box_height) / 2) as i32;
+    let box_area = Rectangle::new(Point::new(box_x, box_y), Size::new(box_width, box_height));
+
+    let _ = box_area
+        .into_styled(PrimitiveStyle::with_fill(C::WHITE))
+        .draw(canvas);
+    let _ = box_area
+        .into_styled(PrimitiveStyle::with_stroke(C::BLACK, 2))
+        .draw(canvas);
+
+    let text_area = Rectangle::new(
+        Point::new(box_x + BOX_PADDING_PX as i32, box_y + BOX_PADDING_PX as i32),
+        Size::new(
+            box_width.saturating_sub(2 * BOX_PADDING_PX),
+            box_height.saturating_sub(2 * BOX_PADDING_PX),
+        ),
+    );
+    let style = MonoTextStyle::new(&FONT_10X20, C::BLACK);
+    let _ = TextBox::new(text, text_area, style).draw(canvas);
+}
+
+pub fn draw_centered_on_frame<C: PanelColor>(
+    frame: Vec<C>,
+    width: u32,
+    height: u32,
+    text: &str,
+) -> Vec<C> {
+    let mut canvas = Canvas::from_vec(width, height, frame);
+    draw_centered(&mut canvas, width, height, text);
+    canvas.into_vec()
+}
+
+fn text_width_px(text: &str, font: &MonoFont<'_>) -> u32 {
+    let char_width = font.character_size.width;
+    text.lines()
+        .map(|line| line.chars().count() as u32 * char_width)
+        .max()
+        .unwrap_or(0)
+}
+
+fn text_height_px(text: &str, font: &MonoFont<'_>) -> u32 {
+    let line_count = text.lines().count().max(1) as u32;
+    line_count * font.character_size.height
+}


### PR DESCRIPTION
## Summary
- rename `disable_charger` to `power_measurement`
- keep E1004 charger HIZ setup behind the new feature while allowing all binaries to build in power-measurement mode
- force normal-mode wakeups to 30 seconds and overlay a clear power-measurement message on the panel
- extract shared centered text-box rendering for test mode and power-measurement overlays

## Validation
- `source /home/claude/export-esp.sh && .githooks/pre-commit`