### PR TITLE
Document and reduce E1001 power use

### DIFF
--- a/POWER.md
+++ b/POWER.md
@@ -150,15 +150,12 @@ Pre-flash costs **~0.4 mWh per cycle (~4-5%)**. At 1/day on the
 ### Network phase
 
 E1004 WiFi assoc + DHCP + HTTP fetch is roughly t=2-10 s in the cycle
-waveform, ~250 mA mean, or **~2.05 mWh per cycle**. Plausible levers:
+waveform, ~250 mA mean, or **~2.05 mWh per cycle**. These measurements
+already include fast WiFi reconnect using the cached BSSID/channel
+hint. Remaining plausible levers:
 
 | Lever | Saved/cycle | Notes |
 |-------|-------------|-------|
 | Halve image size | ~0.4 mWh | Server-side PNG re-encode; 547 KB at 4-color indexed is ~2.3 bpp vs ~2 bpp floor. |
-| Fast WiFi reconnect | ~0.25-0.5 mWh | Cache BSSID + channel in NVS to skip full scan. |
 | Static IP | ~0.26 mWh | Brittle: LAN reorg breaks the device until reflashed. |
 | HTTP `If-Modified-Since` / `ETag` -> 304 | ~1.5 mWh | Only when the server actually returns 304. |
-
-Fast WiFi reconnect is the one item worth keeping in mind if a cheap
-implementation surfaces. Bench it with 5+ cycles per variant against a
-stable AP; single-cycle deltas are below run-to-run noise.

--- a/POWER.md
+++ b/POWER.md
@@ -1,27 +1,51 @@
-Power profile — E1004
-=====================
+Power profiles
+==============
 
-Bench measurements taken with a Nordic Power Profiler Kit II in
-source-meter mode wired to the E1004 BAT pads (replacing the cell)
-at 3700 mV.
+Practical power budget for the supported reTerminal E10xx devices.
+Measurements were taken with a Nordic Power Profiler Kit / PPK2 at
+**3.7 V** supply voltage.
 
-Headline: deep-sleep floor went from **1.585 mA → ~250 µA** (≈6×) by
-clearing one register before `rtc.sleep_deep(...)`.
+Device summary
+--------------
 
-Root cause
-----------
+| Device | Battery assumption | Sleep current | Sleep energy/day | Refresh cycle | Active energy/cycle |
+|--------|--------------------|---------------|------------------|---------------|---------------------|
+| E1001 | 3.7 V, 2000 mAh = 7,400 mWh | **305 µA** | **27.08 mWh/day** | ~143 mA for ~6.75 s | **0.99 mWh** |
+| E1002 | 3.7 V, 2000 mAh = 7,400 mWh | **297.93 µA** | **26.46 mWh/day** | ~122.85 mA for ~24.14 s | **3.05 mWh** |
+| E1004 | 3.7 V, 5000 mAh = 18,500 mWh | **250.32 µA** | **22.23 mWh/day** | ~255.68 mA for ~37.11 s | **9.76 mWh** |
+
+Sleep dominates normal daily use. At one refresh per day, active
+energy is only ~4% of E1001's budget, ~10% of E1002's budget, and
+~31% of E1004's budget.
+
+Expected battery life
+---------------------
+
+| Device | Refresh interval | Active (mWh/day) | Sleep (mWh/day) | Total (mWh/day) | Battery life |
+|--------|------------------|------------------|-----------------|-----------------|--------------|
+| E1001 | **24 h (1/day)** | 0.99 | 27.08 | **28.08** | **~264 days (~8.7 months)** |
+| E1001 | 12 h (2/day) | 1.98 | 27.08 | 29.07 | ~255 days (~8.4 months) |
+| E1001 | 6 h (4/day) | 3.97 | 27.08 | 31.05 | ~238 days (~7.8 months) |
+| E1001 | 1 h (24/day) | 23.80 | 27.08 | 50.88 | ~145 days (~4.8 months) |
+| E1002 | **24 h (1/day)** | 3.05 | 26.46 | **29.50** | **~251 days (~8.2 months)** |
+| E1002 | 12 h (2/day) | 6.10 | 26.46 | 32.55 | ~227 days (~7.5 months) |
+| E1002 | 6 h (4/day) | 12.19 | 26.46 | 38.65 | ~192 days (~6.3 months) |
+| E1002 | 1 h (24/day) | 73.15 | 26.46 | 99.61 | ~74 days (~2.4 months) |
+| E1004 | **24 h (1/day)** | 9.76 | 22.23 | **31.99** | **~578 days (~19 months)** |
+| E1004 | 12 h (2/day) | 19.52 | 22.23 | 41.75 | ~443 days (~14.6 months) |
+| E1004 | 6 h (4/day) | 39.03 | 22.23 | 61.26 | ~302 days (~9.9 months) |
+| E1004 | 1 h (24/day) | 234.20 | 22.23 | 256.43 | ~72 days (~2.4 months) |
+
+Sleep-current fixes
+-------------------
+
+### ESP32-S3 ADC shutdown
 
 [esp-rs/esp-hal#2740](https://github.com/esp-rs/esp-hal/issues/2740):
 `Adc::new` sets `SENS.sar_power_xpd_sar.force_xpd_sar` and nothing in
 the API ever clears it, so the SAR analog stays powered through deep
-sleep. ~1.3 mA constant draw on ESP32-S3 once any code calls
-`Adc::new` — we hit this every cycle through `read_battery`.
-
-esp-hal #5279 (every `WakeSource::apply()` calls
-`set_rtc_peri_pd_en(false)`) was initially suspected of being a
-co-contributor; bench bisection showed it isn't material on this
-hardware. Clearing the SAR XPD bit alone is sufficient to reach the
-~250 µA floor.
+sleep. That costs ~1.3 mA on ESP32-S3 once any code calls `Adc::new`;
+we hit this every cycle through `read_battery`.
 
 Fix in `src/sleep.rs`, immediately before sleep:
 
@@ -31,128 +55,102 @@ SENS::regs()
     .modify(|_, w| unsafe { w.force_xpd_sar().bits(0) });
 ```
 
-Power budget
-------------
+This brought E1004 deep sleep from **1.585 mA** down to **250.32 µA**.
+[esp-rs/esp-hal#5279](https://github.com/esp-rs/esp-hal/issues/5279)
+(`WakeSource::apply()` calling
+`set_rtc_peri_pd_en(false)`) was initially suspected, but bench
+bisection showed it is not material on this hardware.
 
-Cell: **5000 mAh × 3.7 V = 18,500 mWh** nominal.
+### E1001 panel rail shutdown
 
-Per active refresh cycle (cold-boot or button-wake, equivalent):
-**~36 J ≈ 10 mWh**, ~42 s wall-clock end to end.
+E1001 originally slept at **394.67 µA**, higher than E1002's
+**297.93 µA**. Adding the UC8179 `DeepSleep(0xA5)` command after panel
+`PowerOff` only moved E1001 to **~374 µA**, so controller standby was
+not the main source.
 
-| Refresh interval  | Active (mWh/day) | Sleep (mWh/day) | Total (mWh/day) | Battery life     |
-|-------------------|------------------|-----------------|-----------------|------------------|
-| **24 h (1/day)**  | 10               | 22              | **32**          | **~575 days (~19 months)** |
-| 12 h (2/day)      | 20               | 22              | 42              | ~440 days (~14 months)     |
-|  6 h (4/day)      | 40               | 22              | 62              | ~300 days (~10 months)     |
-|  1 h (24/day)     | 240              | 22              | 262             | ~70 days (~2.3 months)     |
+The material fix is holding `SCREEN_RST#` low in the GDEY075T7
+`disable()` path. On E1001 that reset net also drives the 24-pin panel
+load-switch enable, so pulling it low drops the panel rail before ESP
+deep sleep. That accounts for the E1001-specific **~90 µA** sleep
+excess. The UC8179 deep-sleep command is kept anyway as the correct
+controller shutdown sequence before the rail is removed.
 
-Sleep math: 250 µA × 3.7 V × 24 h ≈ 22 mWh/day.
-
-At a daily refresh, sleep is ~70% of daily energy, active ~30%.
-Without the fix, sleep would have been ~140 mWh/day and the same
-1-refresh-per-day cell life would be ~120 days (~4 months) — the fix
-extends life ~4.7× at this duty cycle.
-
-Active cycle waveform
----------------------
-
-| Phase              | Time         | Mean current | Notes                                     |
-|--------------------|--------------|--------------|-------------------------------------------|
-| Boot ramp          | 0 – 2 s      | ~70 → 180 mA | ESP32-S3 + radio bring-up; 1.08 A peak    |
-| WiFi assoc + fetch | 2 – 12 s     | ~250 mA      | sustained, with sub-second 0.5 A bursts   |
-| Panel transition   | 12 – 41 s    | ~180–330 mA  | matches the panel's ~20 s e-ink refresh   |
-| Deep sleep         | 42 s onward  | ~250 µA      |                                           |
-
-Active-phase optimisations — considered, parked
-------------------------------------------------
-
-Once the deep-sleep floor was at the ESP32-S3 hard floor (~250 µA),
-sleep started dominating the daily budget at the typical 1/day refresh
-— **22 of 32 mWh/day, ~70%**. That sets a hard ceiling on what
-active-phase tuning can achieve at this duty cycle:
-
-> Even reducing the entire active phase to zero only extends battery
-> life from ~575 → ~833 days. **Anything we do to active is at most a
-> ~45% gain at 1/day.** Realistic combinations top out around +5–10%.
-
-Two candidate optimisations were investigated; neither shipped.
-
-### White pre-flash → buzzer beep (measured)
-
-The white pre-flash gives ~1 s of immediate visual feedback after a
-button press by kicking off an all-white panel refresh in parallel
-with WiFi fetch. PPK2 measurement of three runs (60 s cold-boot
-captures, `power_measurement` build, 3700 mV):
-
-| Variant | Active-phase energy |
-|---------|---------------------|
-| Stock (with pre-flash), run 1   | 9.413 mWh |
-| Stock (with pre-flash), run 2   | 9.155 mWh |
-| Pre-flash skipped (no feedback) | 8.836 mWh |
-| Buzzer beep instead (80 ms)     | 8.870 mWh |
-
-Pre-flash costs **~0.4 mWh per cycle (~4–5%)** — mostly from the panel
-HV booster running concurrently with WiFi for ~6 s, plus a ~1.4 s
-longer wall-clock cycle. The buzzer alternative (already on hardware
-at GPIO45 via LEDC, used by config_mode) costs ~0.04 mWh — within
-run-to-run noise of the no-feedback case. Net saving from swapping
-would be the full ~0.4 mWh.
-
-At 1/day on the 5000 mAh cell that's **~595 vs ~587 days (+8 days,
-+1.4%)**. Not worth the UX trade (silent visual cue → audible chirp)
-for that gain.
-
-### Network phase (theoretical)
-
-WiFi assoc + DHCP + HTTP fetch is t=2–10 s in the cycle waveform,
-~250 mA mean → **~2.05 mWh per cycle (~22% of active energy)**. The
-levers, in rough order of plausible upside (un-benched estimates):
-
-| Lever | Saved/cycle | Notes |
-|-------|-------------|-------|
-| Halve image size (server-side PNG re-encode)         | ~0.4 mWh | 547 KB at 4-color indexed is ~2.3 bpp vs ~2 bpp floor. |
-| Fast WiFi reconnect (cached BSSID + channel in NVS)  | ~0.25–0.5 mWh | Skips full scan on subsequent associations. |
-| Static IP (skip DHCP)                                | ~0.26 mWh | Brittle — LAN reorg breaks the device until reflashed. |
-| HTTP `If-Modified-Since` / `ETag` → 304              | ~1.5 mWh | Only when the server actually returns 304. |
-
-Combined plausible "all easy wins" ≈ 1.5 mWh/cycle, daily total 31.5
-→ 30.0 mWh/day, battery life 587 → 617 days (**+30 days, +5%** at
-1/day). Theoretical max with 304 caching layered on top ≈ 3 mWh/cycle,
-~+10%.
-
-### Why none of it shipped
-
-A 1.4 mWh/cycle theoretical maximum saving at 1 refresh/day buys
-~10% extra battery life on top of an already-580+-day baseline. None
-of the levers are free — image-size and 304 caching are server-side
-work, static IP adds a maintenance footgun, fast reconnect is hard
-to benchmark reliably. Below the ESP32-S3 sleep floor would require
-external hardware (e.g. RTC-controlled rail cut).
-
-**Fast WiFi reconnect** is the one item kept in mind — if a cheap
-implementation surfaces (esp-radio knob, NVS-cached BSSID/channel),
-it's worth picking up. Bench it with 5+ cycles per variant against
-a stable AP; single-cycle deltas are below run-to-run noise.
-
-Bench setup notes
+Measurement notes
 -----------------
 
-PPK2 in source-meter mode replaces the cell at the BAT pads. Build
-with the `power_measurement` Cargo feature, which parks the SY6974B in
-HIZ on E1004 so the PPK2 sees the real load even with USB-C attached,
-forces a 30-second wake interval, and marks the panel image so bench
-firmware is obvious:
+Measured at 3.7 V with USB disconnected. PPK / PPK2 in source-meter
+mode replaces the cell at the BAT pads.
+
+| Device | Mode | Mean current | Duration | Energy |
+|--------|------|--------------|----------|--------|
+| E1001 | Sleep, before reset/rail fix | 394.67 µA | - | 35.05 mWh/day |
+| E1001 | Sleep, after reset/rail fix | 305 µA | - | 27.08 mWh/day |
+| E1001 | Wake-refresh 1 | 146.79 mA | 6.939 s | 1.05 mWh |
+| E1001 | Wake-refresh 2 | 145.35 mA | 5.942 s | 0.89 mWh |
+| E1001 | Button-refresh 1 | 140.32 mA | 7.038 s | 1.02 mWh |
+| E1001 | Button-refresh 2 | 140.08 mA | 7.067 s | 1.02 mWh |
+| E1002 | Sleep | 297.93 µA | - | 26.46 mWh/day |
+| E1002 | Wake-refresh 1 | 123.62 mA | 24.23 s | 3.08 mWh |
+| E1002 | Wake-refresh 2 | 122.06 mA | 23.20 s | 2.91 mWh |
+| E1002 | Button-refresh 1 | 122.93 mA | 24.62 s | 3.11 mWh |
+| E1002 | Button-refresh 2 | 122.78 mA | 24.51 s | 3.09 mWh |
+| E1004 | Sleep | 250.32 µA | - | 22.23 mWh/day |
+| E1004 | Wake-refresh 1 | 249.73 mA | 36.08 s | 9.26 mWh |
+| E1004 | Wake-refresh 2 | 250.44 mA | 35.84 s | 9.23 mWh |
+| E1004 | Button-refresh 1 | 264.46 mA | 38.37 s | 10.43 mWh |
+| E1004 | Button-refresh 2 | 258.08 mA | 38.15 s | 10.12 mWh |
+
+Active refresh averages **~255.68 mA for ~37.11 s**, or
+**~35.13 J ≈ 9.76 mWh** on E1004.
+
+Build with the `power_measurement` Cargo feature for bench captures.
+It parks the SY6974B in HIZ on E1004, forces a 60-second wake interval,
+and marks the panel image so bench firmware is obvious:
 
 ```
 EXTRA_FEATURES=power_measurement RELEASE=1 ./run.sh e1004 /dev/ttyUSB0 /tmp/flash.log
 ```
 
-Drive the PPK2 from Nordic's nRF Connect for Desktop (Power
-Profiler app) for live current display and capture.
+Active-phase optimisations
+--------------------------
 
-**Bench gotcha:** with `power_measurement` active on E1004, EN_HIZ is sticky
-across ESP32 resets and only clears when VBUS is removed and
-reapplied. Once firmware has run, the device only boots if the PPK2
-is sourcing on BAT — if the supply script exits between flashes, the
-next reset brownouts. Keep one PPK2-supply script running for the
-whole bench session.
+Once the deep-sleep floor is near the ESP32-S3 hard floor, sleep
+dominates the daily budget at the typical 1/day refresh. That limits
+what active-phase tuning can achieve at this duty cycle.
+
+For E1004, even reducing the entire active phase to zero only extends
+battery life from ~578 to ~832 days. Realistic active-phase changes
+are much smaller.
+
+### White pre-flash -> buzzer beep
+
+On E1004, the white pre-flash gives ~1 s of immediate visual feedback
+after a button press by kicking off an all-white panel refresh in
+parallel with WiFi fetch. PPK2 measurement of three runs showed:
+
+| Variant | Active-phase energy |
+|---------|---------------------|
+| Stock with pre-flash, run 1 | 9.413 mWh |
+| Stock with pre-flash, run 2 | 9.155 mWh |
+| Pre-flash skipped | 8.836 mWh |
+| Buzzer beep instead, 80 ms | 8.870 mWh |
+
+Pre-flash costs **~0.4 mWh per cycle (~4-5%)**. At 1/day on the
+5000 mAh E1004 cell, swapping it for a buzzer beep would be roughly
+**+8 days (+1.4%)**, not enough to justify the UX trade.
+
+### Network phase
+
+E1004 WiFi assoc + DHCP + HTTP fetch is roughly t=2-10 s in the cycle
+waveform, ~250 mA mean, or **~2.05 mWh per cycle**. Plausible levers:
+
+| Lever | Saved/cycle | Notes |
+|-------|-------------|-------|
+| Halve image size | ~0.4 mWh | Server-side PNG re-encode; 547 KB at 4-color indexed is ~2.3 bpp vs ~2 bpp floor. |
+| Fast WiFi reconnect | ~0.25-0.5 mWh | Cache BSSID + channel in NVS to skip full scan. |
+| Static IP | ~0.26 mWh | Brittle: LAN reorg breaks the device until reflashed. |
+| HTTP `If-Modified-Since` / `ETag` -> 304 | ~1.5 mWh | Only when the server actually returns 304. |
+
+Fast WiFi reconnect is the one item worth keeping in mind if a cheap
+implementation surfaces. Bench it with 5+ cycles per variant against a
+stable AP; single-cycle deltas are below run-to-run noise.

--- a/POWER.md
+++ b/POWER.md
@@ -105,7 +105,9 @@ Active refresh averages **~255.68 mA for ~37.11 s**, or
 
 Build with the `power_measurement` Cargo feature for bench captures.
 It parks the SY6974B in HIZ on E1004, forces a 60-second wake interval,
-and marks the panel image so bench firmware is obvious:
+and marks the panel image so bench firmware is obvious. HIZ lets you
+measure E1004 power at the battery connector while USB serial remains
+attached; on E1001 / E1002, disconnect USB for power measurements.
 
 ```
 EXTRA_FEATURES=power_measurement RELEASE=1 ./run.sh e1004 /dev/ttyUSB0 /tmp/flash.log

--- a/POWER.md
+++ b/POWER.md
@@ -27,20 +27,11 @@ leakage, charger/power-path quiescent current, or regulator differences.
 Expected battery life
 ---------------------
 
-| Device | Refresh interval | Active (mWh/day) | Sleep (mWh/day) | Total (mWh/day) | Battery life |
-|--------|------------------|------------------|-----------------|-----------------|--------------|
-| E1001 | **24 h (1/day)** | 0.99 | 27.08 | **28.08** | **~264 days (~8.7 months)** |
-| E1001 | 12 h (2/day) | 1.98 | 27.08 | 29.07 | ~255 days (~8.4 months) |
-| E1001 | 6 h (4/day) | 3.97 | 27.08 | 31.05 | ~238 days (~7.8 months) |
-| E1001 | 1 h (24/day) | 23.80 | 27.08 | 50.88 | ~145 days (~4.8 months) |
-| E1002 | **24 h (1/day)** | 3.05 | 26.46 | **29.50** | **~251 days (~8.2 months)** |
-| E1002 | 12 h (2/day) | 6.10 | 26.46 | 32.55 | ~227 days (~7.5 months) |
-| E1002 | 6 h (4/day) | 12.19 | 26.46 | 38.65 | ~192 days (~6.3 months) |
-| E1002 | 1 h (24/day) | 73.15 | 26.46 | 99.61 | ~74 days (~2.4 months) |
-| E1004 | **24 h (1/day)** | 9.76 | 22.23 | **31.99** | **~578 days (~19 months)** |
-| E1004 | 12 h (2/day) | 19.52 | 22.23 | 41.75 | ~443 days (~14.6 months) |
-| E1004 | 6 h (4/day) | 39.03 | 22.23 | 61.26 | ~302 days (~9.9 months) |
-| E1004 | 1 h (24/day) | 234.20 | 22.23 | 256.43 | ~72 days (~2.4 months) |
+| Device | 24 h / 1 day | 12 h | 6 h | 1 h |
+|--------|--------------|------|-----|-----|
+| E1001 | **~264 days (~8.7 months)** | ~255 days (~8.4 months) | ~238 days (~7.8 months) | ~145 days (~4.8 months) |
+| E1002 | **~251 days (~8.2 months)** | ~227 days (~7.5 months) | ~192 days (~6.3 months) | ~74 days (~2.4 months) |
+| E1004 | **~578 days (~19 months)** | ~443 days (~14.6 months) | ~302 days (~9.9 months) | ~72 days (~2.4 months) |
 
 Sleep-current fixes
 -------------------

--- a/POWER.md
+++ b/POWER.md
@@ -27,8 +27,8 @@ leakage, charger/power-path quiescent current, or regulator differences.
 Expected battery life
 ---------------------
 
-| Device | 24 h / 1 day | 12 h | 6 h | 1 h |
-|--------|--------------|------|-----|-----|
+| Wake-up interval | 24 h | 12 h | 6 h | 1 h |
+|------------------|------|------|-----|-----|
 | E1001 | **~264 days (~8.7 months)** | ~255 days (~8.4 months) | ~238 days (~7.8 months) | ~145 days (~4.8 months) |
 | E1002 | **~251 days (~8.2 months)** | ~227 days (~7.5 months) | ~192 days (~6.3 months) | ~74 days (~2.4 months) |
 | E1004 | **~578 days (~19 months)** | ~443 days (~14.6 months) | ~302 days (~9.9 months) | ~72 days (~2.4 months) |

--- a/POWER.md
+++ b/POWER.md
@@ -18,6 +18,12 @@ Sleep dominates normal daily use. At one refresh per day, active
 energy is only ~4% of E1001's budget, ~10% of E1002's budget, and
 ~31% of E1004's budget.
 
+E1001 / E1002 still sleep about **48-55 µA** higher than E1004. We did
+not find a firmware cause after checking ADC shutdown, panel reset
+state, and panel-controller sleep. The remaining difference is
+suspected to be hardware-related: board pull networks, panel/FPC
+leakage, charger/power-path quiescent current, or regulator differences.
+
 Expected battery life
 ---------------------
 

--- a/src/normal_mode.rs
+++ b/src/normal_mode.rs
@@ -140,7 +140,7 @@ const DEFAULT_SUCCESS_SLEEP: Duration = Duration::from_secs(4 * 60 * 60);
 /// wake without the user having to push a button.
 const DEFAULT_ERROR_SLEEP: Duration = Duration::from_secs(600);
 #[cfg(feature = "power_measurement")]
-const POWER_MEASUREMENT_SLEEP: Duration = Duration::from_secs(30);
+const POWER_MEASUREMENT_SLEEP: Duration = Duration::from_secs(60);
 
 /// Optional server hint parsed from the `Refresh:` response header —
 /// carries the target `Instant` at which the next fetch should happen
@@ -407,7 +407,7 @@ where
     #[cfg(feature = "power_measurement")]
     let wakeup_requested = {
         let _server_wakeup_requested = wakeup_requested;
-        println!("Power measurement mode: forcing 30 second wake interval");
+        println!("Power measurement mode: forcing 60 second wake interval");
         embassy_time::Instant::now() + POWER_MEASUREMENT_SLEEP
     };
 
@@ -533,7 +533,7 @@ fn add_power_measurement_overlay<C: PanelColor>(
     height: usize,
 ) -> FrameWithPalette<C> {
     const TEXT: &str =
-        "Power measurement mode\nCharger disabled if supported\nWake interval: 30 seconds";
+        "Power measurement mode\nCharger disabled if supported\nWake interval: 60 seconds";
 
     let FrameWithPalette { frame, mut palette } = frame;
     let frame = text_box::draw_centered_on_frame(frame, width as u32, height as u32, TEXT);

--- a/src/panel/gdey075t7.rs
+++ b/src/panel/gdey075t7.rs
@@ -66,6 +66,7 @@ enum Command {
     PowerSetting = 0x01,           // PWR
     PowerOff = 0x02,               // POF
     PowerOn = 0x04,                // PON
+    DeepSleep = 0x07,              // DSLP; requires check byte 0xA5
     DataStartTransmission1 = 0x10, // DTM1 — 4-gray plane "high" bit
     DisplayRefresh = 0x12,         // DRF
     DataStartTransmission2 = 0x13, // DTM2 — 4-gray plane "low" bit
@@ -307,6 +308,10 @@ where
     }
 
     async fn disable(&mut self) -> Result<(), Self::Error> {
+        // On E1001 the 24-pin panel load-switch enable is tied to
+        // SCREEN_RST#. Holding reset low after the refresh drops that
+        // rail and fixes the ~90 µA E1001 deep-sleep excess.
+        self.rst.set_low().map_err(Gdey075t7Error::RSTError)?;
         Ok(())
     }
 
@@ -384,6 +389,7 @@ where
     async fn power_off(&mut self, spi: &mut SPI) -> Result<(), Self::Error> {
         self.command(spi, Command::PowerOff, []).await?;
         self.wait_until_idle().await?;
+        self.command(spi, Command::DeepSleep, [0xA5]).await?;
         Ok(())
     }
 


### PR DESCRIPTION
## Summary
- add raw Nordic PPK power captures for E1001 and E1002
- send UC8179 deep-sleep before removing the E1001 panel rail
- hold E1001 SCREEN_RST# low after refresh so the panel load-switch rail drops in ESP deep sleep
- document the updated 305 µA E1001 sleep measurement and revised battery-life estimates

## Testing
- pre-commit hook ran rustfmt and clippy for all binaries, including power_measurement