### PR TITLE
Rewrite README for end users

### DIFF
--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -1,0 +1,56 @@
+# Hardware Notes
+
+This file collects panel references, schematics, and implementation notes
+that are useful when working on the firmware. Normal setup instructions
+live in [README.md](./README.md).
+
+## Device Schematics
+
+The E1001, E1002, and E1004 are all ESP32-S3 based devices with similar
+peripherals and different panel pinouts.
+
+- E1001:
+  https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004307_reTerminal_E1001_V1.0_SCH_250805.pdf
+- E1002:
+  https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004321_reTerminal_E1002_V1.0_SCH_250805.pdf
+- E1004:
+  https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004523_reTerminal%20E1004_V1.0_SCH_260105.pdf
+
+## Panels
+
+| Device | Panel | Notes |
+|--------|-------|-------|
+| E1001 | GooDisplay GDEY075T7 | 800x480, 4-level grayscale |
+| E1002 | GooDisplay GDEP073E01 | 800x480, Spectra 6 |
+| E1004 | T133A01 | 1200x1600, Spectra 6, dual-controller |
+
+Panel references:
+
+- E1001 GDEY075T7: https://www.good-display.com/product/396.html
+- E1002 GDEP073E01: https://www.good-display.com/blank7.html?productId=533
+
+The E1004 panel is a 13.3 inch 1200x1600 Spectra 6 panel driven through
+two controllers. See `src/panel/t133a01.rs` for the current command
+sequence.
+
+## Other References
+
+- Rust library for the GDEP073E01 with useful command names:
+  https://github.com/xandronak/gdep073e01/blob/main/src/lib.rs
+- Another ACEP / seven-colour display with a similar command set,
+  useful for the `PanelSetting` scan-order bit:
+  https://github.com/robertmoro/7ColorEPaperPhotoFrame/blob/main/7ColorEPaperPhotoFrame/epd5in65f.cpp
+- Write-up on the technologies behind ACEP:
+  https://hackaday.io/project/179058-understanding-acep-tecnology
+
+## Development Notes
+
+All three panel driver modules are compiled regardless of which binary is
+selected. This intentionally makes driver compile errors visible even
+when building for only one device:
+
+```bash
+cargo build --bin e1001
+cargo build --bin e1002
+cargo build --bin e1004
+```

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -35,6 +35,38 @@ The E1004 panel is a 13.3 inch 1200x1600 Spectra 6 panel driven through
 two controllers. See `src/panel/t133a01.rs` for the current command
 sequence.
 
+## E1004 and GDEP133C02
+
+Good Display's GDEP133C02 ESP-IDF example is a useful comparison point,
+but it does not prove that the E1004's T133A01 panel is the same module:
+
+https://www.good-display.com/companyfile/1755.html
+
+The example matches the broad driver model used by the E1004:
+
+- 1200x1600 Spectra 6 image data, packed as two pixels per byte.
+- Two chip selects for two panel controllers.
+- Image data split into left and right controller halves.
+- The same main command set: `PSR` (`0x00`), `PWR` (`0x01`), `POF`
+  (`0x02`), `PON` (`0x04`), `DTM` (`0x10`), `DRF` (`0x12`), `CDI`
+  (`0x50`), `TCON` (`0x60`), `TRES` (`0x61`), `AN_TM` (`0x74`),
+  `AGID` (`0x86`), `B0`, `B1`, `B6`, `B7`, `CCSET` (`0xE0`), `PWS`
+  (`0xE3`), and `F0`.
+- Very similar init flow: analog timing, `F0`, panel setting, border /
+  TCON / resolution setup, power settings, booster setup, then data
+  transfer and refresh.
+
+Important differences remain:
+
+- Good Display uses `CDI = 0xF7`; the current E1004 driver uses `0x37`.
+- Good Display's `AN_TM` bytes differ from the current driver.
+- Good Display's booster soft-start values are `0xE8, 0x28`; the
+  current driver uses `0xE0, 0x20`.
+
+Treat GDEP133C02 as a related command-family reference unless panel
+markings, vendor confirmation, or a full pinout/mechanical match proves
+that it is the same module as the E1004's T133A01.
+
 ## Other References
 
 - Rust library for the GDEP073E01 with useful command names:

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -30,8 +30,6 @@ Panel references:
 - E1002 GDEP073E01: https://www.good-display.com/blank7.html?productId=533
 - E1004 T133A01 datasheet from Seeed:
   https://files.seeedstudio.com/wiki/Other_Display/1330-E6-epaper/13.3_E6_eInk_Display_module_Datasheet.pdf
-- Related Good Display 13.3 inch Spectra 6 panel, GDEP133C02:
-  https://www.good-display.com/product/559.html
 
 The E1004 panel is a 13.3 inch 1200x1600 Spectra 6 panel driven through
 two controllers. See `src/panel/t133a01.rs` for the current command

--- a/HARDWARE.md
+++ b/HARDWARE.md
@@ -28,6 +28,10 @@ Panel references:
 
 - E1001 GDEY075T7: https://www.good-display.com/product/396.html
 - E1002 GDEP073E01: https://www.good-display.com/blank7.html?productId=533
+- E1004 T133A01 datasheet from Seeed:
+  https://files.seeedstudio.com/wiki/Other_Display/1330-E6-epaper/13.3_E6_eInk_Display_module_Datasheet.pdf
+- Related Good Display 13.3 inch Spectra 6 panel, GDEP133C02:
+  https://www.good-display.com/product/559.html
 
 The E1004 panel is a 13.3 inch 1200x1600 Spectra 6 panel driven through
 two controllers. See `src/panel/t133a01.rs` for the current command

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,6 @@
+# Notes
+
+## Deep Sleep Wake Speed
+
+- ESP32 forum thread on speeding up boot from deep sleep:
+  https://esp32.com/viewtopic.php?t=30954

--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,2 +1,0 @@
-Speeding up booting up from deep sleep:
-https://esp32.com/viewtopic.php?t=30954

--- a/README.md
+++ b/README.md
@@ -1,64 +1,169 @@
-epd-photoframe
-==============
-Purpose
--------
-Playing around with Rust, ESP32, Embassy, and eInk.
+# epd-photoframe
 
-Goal
-----
-Stand-alone firmware that will:
-- Wake up every 10 minutes (configurable), download a pre-dithered palette PNG image, and display it.
-- On each wake-up all sensors (battery, temperature, humidity) should be read and reported (MQTT, HTTP POST, or as headers of the PNG GET).
-- Low power consumption (deep sleep) between wake-ups.
-- Buttons should allow forcing a wake-up and refresh (green) or changing between pages (e.g. different URLs).
-- WiFi settings and URLs are configurable through an Access Point captive portal.
-- Captive portal is entered automatically on a freshly-flashed device (whenever any required NVS key is missing) and can also be re-entered at any boot by holding Previous+Next for 10 s.
+Full-fledged photo frame firmware for Seeed reTerminal E1001, E1002, and
+E1004 e-paper devices.
 
-Originally the full-colour PNG was going to be dithered on the device, but the
-larger E1004 panel (1200×1600) didn't leave enough memory for that approach,
-so image processing has moved off-device: the firmware now expects a
-palette-based PNG that is already quantised to the target device's palette.
+epd-photoframe turns the reTerminal E100x boards into battery-powered
+digital photo frames. The device wakes up, connects to WiFi, fetches one
+already-prepared PNG image, refreshes the e-paper panel, and goes back to
+deep sleep until the next refresh.
 
-Stretch goals:
-- TRMNL compatibility, allowing switching between TRMNL and other URLs via a long-press of the left/right buttons.
-- Load and display images/folders from SD card.
-- Unless triggered by the Refresh button, only refresh the portion of the screen that actually changed (use ESP "RTC" RAM?).
+The firmware is designed to be used with
+[epd-photoframe-server](https://github.com/Frans-Willem/epd-photoframe-server),
+which turns a public Google Photos album into correctly sized, dithered
+images for these panels.
 
-Supported devices
------------------
-Build with `cargo build --bin <device>`:
+## How it fits together
 
-| Binary  | Device      | Panel     | Resolution  | State       |
-|---------|-------------|-----------|-------------|-------------|
-| `e1001` | reTerminal E1001 (7")  | GDEY075T7  | 800×480 (4-level grayscale) | working    |
-| `e1002` | reTerminal E1002 (7")  | GDEP073E01 | 800×480  | working     |
-| `e1004` | reTerminal E1004 (13") | T133A01   | 1200×1600 | working     |
+Three pieces make up the usual setup:
 
-All three panel driver modules are always compiled regardless of the
-selected feature, so changes surface compile errors in every driver.
+- **epd-photoframe** *(this repo)* runs on the frame. It handles WiFi,
+  buttons, battery and sensor reporting, image download, panel refresh,
+  and deep sleep.
+- **[epd-photoframe-server](https://github.com/Frans-Willem/epd-photoframe-server)**
+  runs on a server, NAS, Raspberry Pi, or other always-on machine. It
+  picks photos from a Google Photos album, crops or pads them, draws
+  optional overlays, dithers them to the target panel palette, and
+  returns a PNG.
+- **[epd-dither](https://github.com/Frans-Willem/epd-dither)** does the
+  palette conversion. The server uses it directly; you do not need to
+  install it separately for the frame firmware.
 
-Progress
---------
-Firmware runs on the E1002 and E1004. WiFi credentials and image URL are
-provisioned at runtime through the captive-portal web UI and persisted to
-ESP-IDF NVS. The device refreshes every 10 minutes and on button press,
-fetching a palette-based PNG from the configured URL.
+The frame intentionally does very little image processing itself. This
+keeps the firmware small, reduces wake time, and avoids running into RAM
+limits on the large 1200x1600 E1004 panel.
 
-References
-----------
-Schematics (ESP32-S3 based, similar peripherals, differ in panel pinout):
-- E1001: https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004307_reTerminal_E1001_V1.0_SCH_250805.pdf
-- E1002: https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004321_reTerminal_E1002_V1.0_SCH_250805.pdf
-- E1004: https://files.seeedstudio.com/wiki/reterminal_e10xx/res/202004523_reTerminal%20E1004_V1.0_SCH_260105.pdf
+## Supported devices
 
-Panels:
-- E1001: GooDisplay GDEY075T7 — https://www.good-display.com/product/396.html
-- E1002: GooDisplay GDEP073E01 — https://www.good-display.com/blank7.html?productId=533
-- E1004: T133A01 (1200×1600, Spectra 6, dual-controller)
+| Binary | Device | Panel | Resolution |
+|--------|--------|-------|------------|
+| `e1001` | reTerminal E1001 | GDEY075T7 grayscale e-paper | 800x480 |
+| `e1002` | reTerminal E1002 | GDEP073E01 Spectra 6 e-paper | 800x480 |
+| `e1004` | reTerminal E1004 | T133A01 Spectra 6 e-paper | 1200x1600 |
 
-Other references:
-- Rust library for the GDEP073E01 with nice command names: https://github.com/xandronak/gdep073e01/blob/main/src/lib.rs
-- Another ACEP (7-colour) display with a similar command set, useful for the PanelSetting scan-order bit:
-  https://github.com/robertmoro/7ColorEPaperPhotoFrame/blob/main/7ColorEPaperPhotoFrame/epd5in65f.cpp
-- Write-up on the technologies behind ACEP:
-  https://hackaday.io/project/179058-understanding-acep-tecnology
+All three devices are supported. The E1001 uses 4-level grayscale; the
+E1002 and E1004 use six-colour Spectra 6 panels.
+
+## What it does
+
+- Fetches a paletted PNG over HTTP and displays it on the e-paper panel.
+- Uses the server's `Refresh` header to decide when to wake up again.
+- Reports battery voltage, battery percentage, temperature, humidity,
+  and available charger state as query parameters on each image request.
+- Supports hardware buttons for refresh, previous photo, and next photo.
+- Provides a setup WiFi network and captive portal for configuring WiFi
+  and the image URL.
+- Enters deep sleep between refreshes for long battery life.
+
+## Before flashing
+
+You need:
+
+- A supported Seeed reTerminal E1001, E1002, or E1004.
+- A USB-C cable for flashing and serial logs.
+- A Rust ESP toolchain that can build for `xtensa-esp32s3-none-elf`.
+- `espflash` available in your shell.
+- An image endpoint that returns a panel-sized paletted PNG. For normal
+  use, run
+  [epd-photoframe-server](https://github.com/Frans-Willem/epd-photoframe-server)
+  and point the frame at `/screen/<name>`.
+
+The firmware expects plain `http://` URLs. The setup portal rejects
+`https://` image URLs.
+
+## Flashing
+
+Pick the binary for your device:
+
+```bash
+cargo run --release --bin e1001
+cargo run --release --bin e1002
+cargo run --release --bin e1004
+```
+
+The repository's Cargo configuration uses `espflash flash --monitor` as
+the runner, so `cargo run` flashes the device and opens the serial
+monitor.
+
+If your serial port is not auto-detected, pass it through to `espflash`:
+
+```bash
+cargo run --release --bin e1004 -- --port /dev/ttyUSB0
+```
+
+## First setup
+
+On a freshly flashed device, or whenever required configuration is
+missing, the frame enters setup mode automatically.
+
+1. The frame shows a setup screen with a QR code.
+2. Scan the QR code, or join the WiFi network named
+   `epd-photoframe-setup-XXXX`.
+3. Open `http://192.168.4.1/` if the captive portal does not open
+   automatically.
+4. Enter your WiFi SSID, WiFi password, and image URL.
+5. Save the form. The device restarts and begins fetching images.
+
+To re-enter setup later, reboot the device and hold **Previous** and
+**Next** for 10 seconds during boot.
+
+## Image endpoint
+
+The configured URL should return a PNG that already matches the target
+device's resolution and palette. The firmware does not resize, crop, or
+dither normal photos on-device.
+
+On each request, the firmware may add these query parameters:
+
+- `battery_mv`
+- `battery_pct`
+- `temp_c`
+- `humidity_pct`
+- `power`
+- `action=refresh`, `action=previous`, or `action=next`
+
+The response can include a standard HTTP `Refresh` header. The firmware
+uses that interval for the next timed wake-up, and also supports
+`Refresh: <seconds>; url=<url>` to move to a different URL.
+
+## Buttons
+
+- **Refresh** wakes the frame immediately and requests
+  `action=refresh`.
+- **Previous** requests `action=previous`.
+- **Next** requests `action=next`.
+- Holding **Previous** + **Next** for 10 seconds during boot enters
+  setup mode.
+
+Button actions are most useful with epd-photoframe-server, which maps
+them to refresh, previous-photo, and next-photo behaviour.
+
+## Power and battery life
+
+The firmware is intended for slow refresh schedules: a few times per day
+rather than every few minutes. With the measured E1001, E1002, and E1004
+hardware, expected battery life is on the order of months when waking
+once or twice per day.
+
+See [POWER.md](./POWER.md) for measured sleep current, wake-cycle cost,
+and battery-life estimates.
+
+## Hardware notes
+
+Panel references, schematics, and lower-level hardware notes live in
+[HARDWARE.md](./HARDWARE.md). They are useful when changing panel
+drivers or investigating board behaviour, but are not needed for normal
+use.
+
+## A note on LLM use
+
+I made heavy use of Claude while building this. I was closely involved
+throughout - every change Claude proposed was reviewed before it landed,
+and I personally stand by the quality of the code in this repo. What an
+LLM gave me was time: enough of it to take this project from "works on
+my desk" to something polished enough for other people to use, which I
+wouldn't otherwise have done as a side project.
+
+That said, plenty of suggestions Claude made along the way were
+nonsense, and I would not trust an LLM to write code unsupervised after
+this experience. Use accordingly.

--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ use.
 
 ## A note on LLM use
 
-I made heavy use of Claude while building this. I was closely involved
-throughout - every change Claude proposed was reviewed before it landed,
-and I personally stand by the quality of the code in this repo. What an
-LLM gave me was time: enough of it to take this project from "works on
-my desk" to something polished enough for other people to use, which I
-wouldn't otherwise have done as a side project.
+I made heavy use of Anthropic Claude and OpenAI Codex while building
+this. I was closely involved throughout - every change they proposed was
+reviewed before it landed, and I personally stand by the quality of the
+code in this repo. What LLMs gave me was time: enough of it to take this
+project from "works on my desk" to something polished enough for other
+people to use, which I wouldn't otherwise have done as a side project.
 
 That said, plenty of suggestions Claude made along the way were
 nonsense, and I would not trust an LLM to write code unsupervised after

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Full-fledged photo frame firmware for Seeed reTerminal E1001, E1002, and
 E1004 e-paper devices.
 
-epd-photoframe turns the reTerminal E100x boards into battery-powered
+epd-photoframe turns the reTerminal E100x devices into battery-powered
 digital photo frames. The device wakes up, connects to WiFi, fetches one
 already-prepared PNG image, refreshes the e-paper panel, and goes back to
 deep sleep until the next refresh.
@@ -152,8 +152,8 @@ and battery-life estimates.
 
 Panel references, schematics, and lower-level hardware notes live in
 [HARDWARE.md](./HARDWARE.md). They are useful when changing panel
-drivers or investigating board behaviour, but are not needed for normal
-use.
+drivers or investigating hardware behaviour, but are not needed for
+normal use.
 
 ## A note on LLM use
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,6 +8,25 @@ whether compatibility means speaking a TRMNL-compatible HTTP endpoint,
 matching TRMNL button semantics, reusing any panel-waveform behaviour,
 or some smaller subset of those.
 
+## SD-card image source
+
+Possible future work: load and display images or folders from SD card
+instead of always fetching from HTTP. Before implementing this, decide
+whether the SD card stores already-dithered panel PNGs, server-style
+source photos that still need off-device processing, or a small set of
+diagnostic/test images only.
+
+## Partial refresh / unchanged-region refresh
+
+Possible future work: unless a refresh was explicitly triggered by the
+Refresh button, refresh only the portion of the screen that actually
+changed. This depends on what each panel/controller can do safely:
+E1001 has an established partial-update path for black/white fast
+refresh, while the Spectra 6 panels may require full-panel refreshes for
+good colour quality and ghosting control. If this is revisited, start by
+checking the panel datasheets and whether retaining enough previous-frame
+state in RTC RAM or flash is worth the complexity.
+
 ## Static-IP + explicit WPA auth-type configuration
 
 The current NVS schema stores just the three fields the portal form

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,13 @@
 # TODO
 
+## Possible TRMNL compatibility
+
+TRMNL compatibility might be useful eventually, but it is not a current
+goal and may never be implemented. If we do pick it up, decide first
+whether compatibility means speaking a TRMNL-compatible HTTP endpoint,
+matching TRMNL button semantics, reusing any panel-waveform behaviour,
+or some smaller subset of those.
+
 ## Static-IP + explicit WPA auth-type configuration
 
 The current NVS schema stores just the three fields the portal form

--- a/TODO.md
+++ b/TODO.md
@@ -11,10 +11,12 @@ or some smaller subset of those.
 ## SD-card image source
 
 Possible future work: load and display images or folders from SD card
-instead of always fetching from HTTP. Before implementing this, decide
-whether the SD card stores already-dithered panel PNGs, server-style
-source photos that still need off-device processing, or a small set of
-diagnostic/test images only.
+instead of always fetching from HTTP. The SD card should store
+already-sized, already-dithered panel images; dithering server-style
+source photos on-device is not feasible on the E1004 because the
+1200x1600 panel does not leave enough memory for that pipeline. Before
+implementing this, decide whether SD-card support is for normal
+preprocessed photo rotation, diagnostic/test images only, or both.
 
 ## Partial refresh / unchanged-region refresh
 


### PR DESCRIPTION
## Summary
- rewrite README around end-user setup and normal usage
- document how the firmware fits with epd-photoframe-server and epd-dither
- move panel/reference details into HARDWARE.md
- move TRMNL compatibility to TODO as possible future work

## Verification
- commit hook ran rustfmt and clippy for all binaries, including power_measurement